### PR TITLE
Added getAssetUrl method to retrieve the fully prepared url of an asset

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -116,7 +116,7 @@ class BassetManager
     }
 
     /**
-     * Returns the asset proper path and url.
+     * Returns the asset path.
      *
      * @param  string  $asset
      * @return string
@@ -124,7 +124,19 @@ class BassetManager
     public function getAssetPath(string $asset): string
     {
         return Str::of($this->basePath)
-            ->append(str_replace([base_path(), 'http://', 'https://', '://', '<', '>', ':', '"', '|', '?', "\0", '*', '`', ';', "'", '+'], '', $asset));
+            ->append(str_replace([base_path(), 'http://', 'https://', '://', '<', '>', ':', '"', '|', '?', "\0", '*', '`', ';', "'", '+'], '', $asset))
+            ->replace('/\\', '/');
+    }
+
+    /**
+     * Returns the asset url.
+     *
+     * @param  string  $asset
+     * @return string
+     */
+    public function getAssetUrl(string $asset): string
+    {
+        return $this->disk->url($this->getAssetPath($asset));
     }
 
     /**


### PR DESCRIPTION
This adds the `getAssetUrl`.

This is useful for situations where we need the URL of an asset, like in FileManager;

The sounds were internalized using `@basset`; https://github.com/Laravel-Backpack/FileManager/pull/25/files#diff-e161d508efed9cb6c7537b960723e83762c3d11483e3f29d1ee79fc27f395627R21

![image](https://user-images.githubusercontent.com/1838187/228398447-3618acd9-5f7c-4677-8e48-389c104d53c6.png)

Then the sounds are used in Javascript;
![image](https://user-images.githubusercontent.com/1838187/228398498-9be189af-4ae0-4335-bf97-f8d35b000f8d.png)

That could only be achieved by adding this method.
