### PR TITLE
DEV mode - config to disable internalization

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -135,10 +135,10 @@ class BassetManager
     }
 
     /**
-     * Gets the name of the file with the hash corresponding to the code block
+     * Gets the name of the file with the hash corresponding to the code block.
      *
-     * @param string $code
-     * @param string $asset
+     * @param  string  $code
+     * @param  string  $asset
      * @return string
      */
     public function getPathHashed(string $asset, string $content): string
@@ -147,6 +147,7 @@ class BassetManager
 
         // get the hash for the content
         $hash = substr(md5($content), 0, 8);
+
         return preg_replace('/\.(css|js)$/i', "-{$hash}.$1", $path);
     }
 
@@ -250,6 +251,7 @@ class BassetManager
         // fallback to code on dev mode
         if ($this->dev) {
             echo $code;
+
             return StatusEnum::DISABLED;
         }
 

--- a/src/Enums/StatusEnum.php
+++ b/src/Enums/StatusEnum.php
@@ -8,4 +8,5 @@ enum StatusEnum: string
     case IN_CACHE = 'Already in cache';
     case INTERNALIZED = 'Internalized';
     case INVALID = 'Not in a CDN or local filesystem, falling back to provided path';
+    case DISABLED = 'Development mode active';
 }

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -2,7 +2,7 @@
 
 return [
     // development mode, assets will not be internalized
-    'dev_mode' => false,
+    'dev_mode' => env('BASSET_DEV_MODE', false),
 
     // disk and path where to store bassets
     'disk' => 'public',

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    // development mode, assets will not be internalized
+    'dev_mode' => false,
+
     // disk and path where to store bassets
     'disk' => 'public',
     'path' => 'basset',

--- a/tests/Feature/BassetBlockTest.php
+++ b/tests/Feature/BassetBlockTest.php
@@ -7,7 +7,9 @@ it('stores basset block', function ($asset) {
 
     $result = basset()->bassetBlock($asset, $codeBlock, false);
 
-    disk()->assertExists(basset()->getPath($asset));
+    $path = basset()->getPathHashed($asset, $codeBlock);
+
+    disk()->assertExists($path);
 
     expect($result)->toBe(StatusEnum::INTERNALIZED);
 })->with('codeBlock');
@@ -16,7 +18,8 @@ it('cleans basset block', function ($asset) {
     $codeBlock = getStub($asset);
 
     basset()->bassetBlock($asset, $codeBlock, false);
-    $path = basset()->getPath($asset);
+
+    $path = basset()->getPathHashed($asset, $codeBlock);
 
     // validate the ouput content
     expect(getStub("$asset.output"))->toBe(disk()->get($path));

--- a/tests/Feature/DevModeTest.php
+++ b/tests/Feature/DevModeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Backpack\Basset\Enums\StatusEnum;
+
+it('ignores cdn basset on dev mode', function ($asset) {
+    // set dev mode
+    config(['backpack.basset.dev_mode' => true]);
+
+    $result = basset($asset, false);
+    $path = basset()->getPath($asset);
+
+    // expect the output of the asset
+    $this->expectOutputRegex("/$asset/");
+
+    // assert file was not saved
+    disk()->assertMissing($path);
+
+    // assert no download was tried
+    Http::assertSentCount(0);
+
+    expect($result)->toBe(StatusEnum::DISABLED);
+})->with('cdn');
+
+it('re-internalizes local basset on dev mode', function ($asset) {
+    // set dev mode
+    config(['backpack.basset.dev_mode' => true]);
+
+    // create the stub resource in disk
+    disk()->put($asset, getStub($asset));
+    $path = disk()->path($asset);
+
+    // internalize the file
+    $result = basset($path, false);
+    $path = basset()->getPath($path);
+
+    // assert file was not saved
+    disk()->assertExists($path);
+
+    expect($result)->toBe(StatusEnum::INTERNALIZED);
+})->with('local');
+
+it('ignores basset block on dev mode', function ($asset) {
+    // set dev mode
+    config(['backpack.basset.dev_mode' => true]);
+
+    $codeBlock = getStub($asset);
+
+    $result = basset()->bassetBlock($asset, $codeBlock, false);
+
+    $path = basset()->getPathHashed($asset, $codeBlock);
+
+    // expect the output string
+    $this->expectOutputString($codeBlock);
+
+    // assert file was not saved
+    disk()->assertMissing($path);
+
+    expect($result)->toBe(StatusEnum::DISABLED);
+})->with('codeBlock');


### PR DESCRIPTION
Related with https://github.com/Laravel-Backpack/basset/issues/16.

I did it with a small change for basset blocks; I thought it would be better to output the code block instead of internalizing it, also because this PR introduces a small new change;

`@bassetBlock` is now generating an hash and appending it to the file name, that way any minor change in the code will render a different file 👌

It is **super fast**, (the ~75 bassetBlocks on monster edit take way less than **1ms** to generate every hash) I run some benchmarks with `md5`, `sha1` and `Hash`, `md5` was the fastest and it's more than enough, I'm using the first 8 bytes to append to the file — 1 in 3 thousand billion hit chance is more than enough 😅

---
So regarding dev mode;

- [x] CDNs - use directly
- [x] local bassets - internalize even if already internalized
- [x] basset blocks - ~~internalize even if already internalized~~ renders code block
- [x] basset directory - internalize even if already internalized
- [x] local basset archive - internalize even if already internalized
- [x] online basset archive - do nothing differently (internalize only if not already internalized)

Also added tests for basset and bassetBlock, archive and directory are still missing generally.