### PR TITLE
ViewPaths — way for 3rd party packages to add internalization paths

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
  */
 class BassetManager
 {
+    use Traits\ViewPathsTrait;
     use Traits\UnarchiveTrait;
 
     private $loaded;
@@ -28,6 +29,9 @@ class BassetManager
         $cachebusting = config('backpack.basset.cachebusting');
         $this->cachebusting = $cachebusting ? (string) Str::of($cachebusting)->start('?') : '';
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');
+
+        // initialize static view path methods
+        $this->initViewPaths();
     }
 
     /**

--- a/src/Console/Commands/BassetInternalize.php
+++ b/src/Console/Commands/BassetInternalize.php
@@ -3,6 +3,7 @@
 namespace Backpack\Basset\Console\Commands;
 
 use Backpack\Basset\Enums\StatusEnum;
+use Backpack\Basset\Facades\Basset;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -40,22 +41,22 @@ class BassetInternalize extends Command
     {
         $starttime = microtime(true);
 
+        $viewPaths = Basset::getViewPaths();
+
         $this->line('Looking for bassets under the following directories:');
-        $directories = collect(config('backpack.basset.view_paths'))
-            ->map(function ($dir) {
-                return (string) Str::of($dir)->after(base_path())->trim('\\/');
-            });
 
         // Find bassets
         $totalFiles = 0;
-        $bassets = $directories
-            ->map(function (string $directory) use (&$totalFiles) {
+        $bassets = collect($viewPaths)
+            ->map(function (string $path) use (&$totalFiles) {
                 // Map all blade files
-                $files = $this->getBladeFiles(base_path($directory));
+                $files = $this->getBladeFiles($path);
                 $count = count($files);
                 $totalFiles += $count;
 
-                $this->line(" - $directory ($count blade files)");
+                $relativePath = Str::of($path)->after(base_path())->trim('\\/');
+
+                $this->line(" - $relativePath ($count blade files)");
 
                 return $files;
             })

--- a/src/Traits/ViewPathsTrait.php
+++ b/src/Traits/ViewPathsTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Backpack\Basset\Traits;
+
+use Illuminate\Support\Facades\File;
+
+trait ViewPathsTrait
+{
+    private static $viewPaths = [];
+
+    /**
+     * Initialize view paths
+     *
+     * @return void
+     */
+    private static function initViewPaths(): void
+    {
+        self::$viewPaths = config('backpack.basset.view_paths', []);
+    }
+
+    /**
+     * Add a view path that may use @basset directive
+     * This is used to internalize assets in advance
+     * with the command artisan basset:internalize
+     *
+     * @param string $path
+     * @return void
+     */
+    public static function addViewPath(string $path): void
+    {
+        if (! in_array($path, self::$viewPaths)) {
+            self::$viewPaths[] = $path;
+        }
+    }
+
+    /**
+     * Gets the current view paths
+     *
+     * @return array
+     */
+    public static function getViewPaths(): array
+    {
+        return self::$viewPaths;
+    }
+}

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -12,7 +12,5 @@ return [
     // used to internalize assets in advance with artisan basset:internalize
     'view_paths' => [
         resource_path('views'),
-        base_path('vendor/backpack/crud/src/resources'),
-        base_path('vendor/backpack/pro/resources'),
     ],
 ];


### PR DESCRIPTION
Related with https://github.com/Laravel-Backpack/basset/issues/15.

```php
Basset::addViewPath('...');
```