### PR TITLE
Avoid certificate expired errors

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -190,7 +190,7 @@ class BassetManager
 
         // Download/copy file
         if (str_starts_with($asset, 'http') || str_starts_with($asset, '://')) {
-            $content = Http::get($asset)->getBody();
+            $content = Http::withoutVerifying()->get($asset)->getBody();
         } else {
             $content = File::get($asset);
         }
@@ -299,7 +299,7 @@ class BassetManager
             $file = $this->getTemporaryFilePath();
 
             // download file to temporary location
-            $content = Http::get($asset)->getBody();
+            $content = Http::withoutVerifying()->get($asset)->getBody();
             File::put($file, $content);
         }
 


### PR DESCRIPTION
Today the certificate for `https://cdn.ckeditor.com/` expired for a couple of hours.
I'm not 100% sure about this PR, but if it doesn't bring any issues, we may want to avoid this kind of errors in CND providers.