### PR TITLE
Added measuring execution time middleware

### DIFF
--- a/src/Http/Middleware/LogExecutionTime.php
+++ b/src/Http/Middleware/LogExecutionTime.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Backpack\Basset\Http\Middleware;
+
+use Backpack\Basset\Facades\Basset;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class LogExecutionTime
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    /**
+     * Logs the Basset execution time
+     *
+     * @return void
+     */
+    public function terminate(): void
+    {
+        Log::info('Basset run '.Basset::getTotalCalls().' times, with an exeuction time of '.Basset::getLoadingTime());
+    }
+}

--- a/src/Http/Middleware/LogExecutionTime.php
+++ b/src/Http/Middleware/LogExecutionTime.php
@@ -22,7 +22,7 @@ class LogExecutionTime
     }
 
     /**
-     * Logs the Basset execution time
+     * Logs the Basset execution time.
      *
      * @return void
      */

--- a/src/Traits/TimeMeasureTrait.php
+++ b/src/Traits/TimeMeasureTrait.php
@@ -11,7 +11,7 @@ trait TimeMeasureTrait
     private $calls = 0;
 
     /**
-     * Start a measuring
+     * Start a measuring.
      *
      * @return void
      */
@@ -21,7 +21,7 @@ trait TimeMeasureTrait
     }
 
     /**
-     * Stop a measuring
+     * Stop a measuring.
      *
      * @return StatusEnum
      */
@@ -34,9 +34,9 @@ trait TimeMeasureTrait
     }
 
     /**
-     * Get total time measured
+     * Get total time measured.
      *
-     * @return integer
+     * @return int
      */
     public function getLoadingTime(): float
     {
@@ -44,9 +44,9 @@ trait TimeMeasureTrait
     }
 
     /**
-     * Get total runs
+     * Get total runs.
      *
-     * @return integer
+     * @return int
      */
     public function getTotalCalls(): float
     {

--- a/src/Traits/TimeMeasureTrait.php
+++ b/src/Traits/TimeMeasureTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Backpack\Basset\Traits;
+
+use Backpack\Basset\Enums\StatusEnum;
+
+trait TimeMeasureTrait
+{
+    private $startTime = 0;
+    private $loadingTime = 0;
+    private $calls = 0;
+
+    /**
+     * Start a measuring
+     *
+     * @return void
+     */
+    public function startRequest(): void
+    {
+        $this->startTime = microtime(true);
+    }
+
+    /**
+     * Stop a measuring
+     *
+     * @return StatusEnum
+     */
+    public function finishRequest(StatusEnum $result): StatusEnum
+    {
+        $this->calls++;
+        $this->loadingTime += microtime(true) - $this->startTime;
+
+        return $result;
+    }
+
+    /**
+     * Get total time measured
+     *
+     * @return integer
+     */
+    public function getLoadingTime(): float
+    {
+        return $this->loadingTime;
+    }
+
+    /**
+     * Get total runs
+     *
+     * @return integer
+     */
+    public function getTotalCalls(): float
+    {
+        return $this->calls;
+    }
+}


### PR DESCRIPTION
In order to log the execution time, one should add the provided middleware to kernel;

`app\Http\Kernel.php`
```diff
    protected $middleware = [
        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \Backpack\Basset\Http\Middleware\LogExecutionTime::class,
    ];
```

---

`storage\logs\laravel.log`
![image](https://user-images.githubusercontent.com/1838187/232209124-b91f00c2-5307-4475-8c23-1c75f4bcdada.png)
