### PR TITLE
Added Cache Map (.basset)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           coverage: none
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,19 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v1
         with:
-          path: '~/.composer/cache/files'
-          key: 'dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles(composer.json) }}'
+          path: ~/.composer/cache/files
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         run: |
-          'composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update'
-          'composer install --no-interaction --no-progress'
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer install --no-interaction --no-progress
 
       - name: PHP Stan Analyse
-        run: 'composer analyse'
+        run: composer analyse
 
       - name: PHP Tests
-        run: 'composer test'
+        run: composer test
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,19 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v1
         with:
-          path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles(composer.json) }}
+          path: '~/.composer/cache/files'
+          key: 'dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles(composer.json) }}'
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer install --no-interaction --no-progress
+          'composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update'
+          'composer install --no-interaction --no-progress'
 
       - name: PHP Stan Analyse
-        run: composer analyse
+        run: 'composer analyse'
 
       - name: PHP Tests
-        run: composer test
+        run: 'composer test'
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "nunomaduro/collision": "^6.0|^7.2",
         "pestphp/pest": "^1.22|^2.5",
         "pestphp/pest-plugin-laravel": "^1.4|^2.0",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^7.22|^8.5",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "require-dev": {
         "phpunit/phpunit": "~9.0|~10.0",
         "nunomaduro/collision": "^6.0|^7.2",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest": "^1.22|^2.5",
+        "pestphp/pest-plugin-laravel": "^1.4|^2.0",
         "orchestra/testbench": "^8.0",
         "phpstan/phpstan": "^1.10"
     },

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -35,7 +35,7 @@ class BassetManager
 
         /** @var FilesystemAdapter */
         $disk = Storage::disk(config('backpack.basset.disk'));
-        
+
         $this->disk = $disk;
         $this->cachebusting = '?'.substr(md5(base_path('composer.lock')), 0, 12);
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -161,7 +161,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool | string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
     {
         $this->loading->start();
 

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -151,7 +151,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool | string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
     {
         // Get asset path
         $path = $this->getPath(is_string($output) ? $output : $asset);
@@ -164,7 +164,6 @@ class BassetManager
 
         // Validate the asset is an absolute path or a CDN
         if (! str_starts_with($asset, base_path()) && ! str_starts_with($asset, 'http') && ! str_starts_with($asset, '://')) {
-
             // may be an internalized asset (folder or zip)
             if ($this->disk->exists($path)) {
                 $asset = $this->disk->url($path);

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Backpack\Basset;
 
 use Backpack\Basset\Facades\Basset;
-use Backpack\Basset\Helpers\CacheMap;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -34,7 +33,7 @@ class BassetServiceProvider extends ServiceProvider
         }
 
         // Run the terminate commands
-        $this->app->terminating(fn() => $this->terminate());
+        $this->app->terminating(fn () => $this->terminate());
     }
 
     /**
@@ -63,7 +62,7 @@ class BassetServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Register the service the package provides.
-        $this->app->singleton('basset', fn() => new BassetManager());
+        $this->app->singleton('basset', fn () => new BassetManager());
 
         // Merge the configuration file.
         $this->mergeConfigFrom(__DIR__.'/config/backpack/basset.php', 'backpack.basset');
@@ -137,7 +136,7 @@ class BassetServiceProvider extends ServiceProvider
     }
 
     /**
-     * On terminate callback
+     * On terminate callback.
      *
      * @return void
      */

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Basset;
 
-use Backpack\Basset\BassetManager;
 use Backpack\Basset\Facades\Basset;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\Basset;
 
+use Backpack\Basset\BassetManager;
 use Backpack\Basset\Facades\Basset;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
@@ -142,12 +143,13 @@ class BassetServiceProvider extends ServiceProvider
      */
     public function terminate(): void
     {
+        /** @var BassetManager */
         $basset = app('basset');
 
         // Log execution time
         if (config('backpack.basset.log_execution_time', false)) {
-            $totalCalls = $basset->loading->getTotalCalls();
-            $loadingTime = $basset->loading->getLoadingTime();
+            $totalCalls = $basset->loader->getTotalCalls();
+            $loadingTime = $basset->loader->getLoadingTime();
 
             Log::info("Basset run $totalCalls times, with an exeuction time of $loadingTime");
         }

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -75,7 +75,6 @@ class BassetServiceProvider extends ServiceProvider
     protected function registerBladeDirectives()
     {
         $this->callAfterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
-
             // Basset
             $bladeCompiler->directive('basset', function (string $parameter): string {
                 return "<?php Basset::basset({$parameter}); ?>";

--- a/src/Console/Commands/BassetClear.php
+++ b/src/Console/Commands/BassetClear.php
@@ -42,6 +42,7 @@ class BassetClear extends Command
 
         $disk->deleteDirectory($path);
         $disk->makeDirectory($path);
+        $disk->delete('.basset');
 
         $this->info('Done');
     }

--- a/src/Console/Commands/BassetInternalize.php
+++ b/src/Console/Commands/BassetInternalize.php
@@ -67,8 +67,7 @@ class BassetInternalize extends Command
                 preg_match_all('/@(basset|bassetArchive|bassetDirectory)\((.+)\)/', $content, $matches);
 
                 $matches[2] = collect($matches[2])
-                    ->map(fn($match) =>
-                        collect(explode(',', $match))
+                    ->map(fn ($match) => collect(explode(',', $match))
                             ->map(function ($arg) {
                                 try {
                                     return eval("return $arg;");
@@ -79,7 +78,7 @@ class BassetInternalize extends Command
                             ->toArray()
                     );
 
-                return collect($matches[1])->map(fn(string $type, int $i) => [$type, $matches[2][$i]]);
+                return collect($matches[1])->map(fn (string $type, int $i) => [$type, $matches[2][$i]]);
             });
 
         $totalBassets = count($bassets);
@@ -97,7 +96,6 @@ class BassetInternalize extends Command
 
         // Cache the bassets
         $bassets->eachSpread(function (string $type, array $args, int $i) use ($bar) {
-
             // Force output of basset to be false
             if ($type === 'basset') {
                 $args[1] = false;

--- a/src/Console/Commands/BassetInternalize.php
+++ b/src/Console/Commands/BassetInternalize.php
@@ -116,6 +116,9 @@ class BassetInternalize extends Command
             }
         });
 
+        // Save the cache map
+        app('basset')->cacheMap->save();
+
         $bar->finish();
         $this->newLine(2);
         $this->info(sprintf('Done in %.2fs', microtime(true) - $starttime));

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Backpack\Basset\Helpers;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+class CacheMap
+{
+    private $map = [];
+    private $path;
+    private $active = false;
+    private $dirty = false;
+
+    public function __construct()
+    {
+        $this->active = config('backpack.basset.cache_map', false);
+        $this->path = Storage::disk(config('backpack.basset.disk'))->path('.basset');
+
+        if (! $this->active) {
+            return;
+        }
+
+        // Load map
+        $this->map = File::exists($this->path) ? json_decode(File::get($this->path), true) : [];
+    }
+
+    /**
+     * Saves the cache map to the .basset file
+     *
+     * @return void
+     */
+    public function save(): void
+    {
+        if (! $this->dirty || ! $this->active) {
+            return;
+        }
+
+        // save file
+        File::put($this->path, json_encode($this->map, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Adds an asset to the cache map
+     *
+     * @param string $asset
+     * @param string $path
+     * @return void
+     */
+    public function add(string $asset, string | bool $path = true): void
+    {
+        if (! $this->active) {
+            return;
+        }
+
+        $this->map[$asset] = $path;
+        $this->dirty = true;
+    }
+
+    /**
+     * Gets the asset url from map
+     *
+     * @param string $asset
+     * @return string | false
+     */
+    public function get(string $asset): string | false
+    {
+        if (! $this->active) {
+            return false;
+        }
+
+        return $this->map[$asset] ?? false;
+    }
+}

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -9,15 +9,15 @@ class CacheMap
 {
     private $map = [];
     private $path;
-    private $active = false;
-    private $dirty = false;
+    private $isActive = false;
+    private $isDirty = false;
 
     public function __construct()
     {
-        $this->active = config('backpack.basset.cache_map', false);
+        $this->isActive = config('backpack.basset.cache_map', false);
         $this->path = Storage::disk(config('backpack.basset.disk'))->path('.basset');
 
-        if (! $this->active) {
+        if (! $this->isActive) {
             return;
         }
 
@@ -32,7 +32,7 @@ class CacheMap
      */
     public function save(): void
     {
-        if (! $this->dirty || ! $this->active) {
+        if (! $this->isDirty || ! $this->isActive) {
             return;
         }
 
@@ -47,14 +47,14 @@ class CacheMap
      * @param  string  $path
      * @return void
      */
-    public function add(string $asset, string|bool $path = true): void
+    public function addAsset(string $asset, string | bool $path = true): void
     {
-        if (! $this->active) {
+        if (! $this->isActive) {
             return;
         }
 
         $this->map[$asset] = $path;
-        $this->dirty = true;
+        $this->isDirty = true;
     }
 
     /**
@@ -63,9 +63,9 @@ class CacheMap
      * @param  string  $asset
      * @return string | false
      */
-    public function get(string $asset): string|false
+    public function getAsset(string $asset): string | false
     {
-        if (! $this->active) {
+        if (! $this->isActive) {
             return false;
         }
 

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -89,9 +89,9 @@ class CacheMap
     }
 
     /**
-     * Normalize asset path to remove unwanted system paths
+     * Normalize asset path to remove unwanted system paths.
      *
-     * @param string $asset
+     * @param  string  $asset
      * @return string
      */
     private function normalizeAsset(string $asset): string

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -26,7 +26,7 @@ class CacheMap
     }
 
     /**
-     * Saves the cache map to the .basset file
+     * Saves the cache map to the .basset file.
      *
      * @return void
      */
@@ -41,13 +41,13 @@ class CacheMap
     }
 
     /**
-     * Adds an asset to the cache map
+     * Adds an asset to the cache map.
      *
-     * @param string $asset
-     * @param string $path
+     * @param  string  $asset
+     * @param  string  $path
      * @return void
      */
-    public function add(string $asset, string | bool $path = true): void
+    public function add(string $asset, string|bool $path = true): void
     {
         if (! $this->active) {
             return;
@@ -58,12 +58,12 @@ class CacheMap
     }
 
     /**
-     * Gets the asset url from map
+     * Gets the asset url from map.
      *
-     * @param string $asset
+     * @param  string  $asset
      * @return string | false
      */
-    public function get(string $asset): string | false
+    public function get(string $asset): string|false
     {
         if (! $this->active) {
             return false;

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -5,6 +5,7 @@ namespace Backpack\Basset\Helpers;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class CacheMap
 {
@@ -56,7 +57,7 @@ class CacheMap
             return;
         }
 
-        $this->map[$asset] = $path;
+        $this->map[$asset] = Str::of($path)->after(url(''))->start('/');
         $this->isDirty = true;
     }
 
@@ -68,10 +69,10 @@ class CacheMap
      */
     public function getAsset(string $asset): string|false
     {
-        if (! $this->isActive) {
+        if (! $this->isActive || ! ($this->map[$asset] ?? false)) {
             return false;
         }
 
-        return $this->map[$asset] ?? false;
+        return url($this->map[$asset]);
     }
 }

--- a/src/Helpers/LoadingTime.php
+++ b/src/Helpers/LoadingTime.php
@@ -6,9 +6,9 @@ use Backpack\Basset\Enums\StatusEnum;
 
 class LoadingTime
 {
-    private $startTime = 0;
-    private $time = 0;
-    private $calls = 0;
+    private float $startTime = 0;
+    private float $time = 0;
+    private int $calls = 0;
 
     /**
      * Start a measuring.

--- a/src/Helpers/LoadingTime.php
+++ b/src/Helpers/LoadingTime.php
@@ -11,7 +11,7 @@ class LoadingTime
     private $calls = 0;
 
     /**
-     * Start a measuring
+     * Start a measuring.
      *
      * @return void
      */
@@ -21,7 +21,7 @@ class LoadingTime
     }
 
     /**
-     * Stop a measuring
+     * Stop a measuring.
      *
      * @return StatusEnum
      */
@@ -34,7 +34,7 @@ class LoadingTime
     }
 
     /**
-     * Get total time measured in miliseconds
+     * Get total time measured in miliseconds.
      *
      * @return float
      */
@@ -44,9 +44,9 @@ class LoadingTime
     }
 
     /**
-     * Get total runs
+     * Get total runs.
      *
-     * @return integer
+     * @return int
      */
     public function getTotalCalls(): int
     {

--- a/src/Helpers/LoadingTime.php
+++ b/src/Helpers/LoadingTime.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Backpack\Basset\Helpers;
+
+use Backpack\Basset\Enums\StatusEnum;
+
+class LoadingTime
+{
+    private $startTime = 0;
+    private $time = 0;
+    private $calls = 0;
+
+    /**
+     * Start a measuring
+     *
+     * @return void
+     */
+    public function start(): void
+    {
+        $this->startTime = microtime(true);
+    }
+
+    /**
+     * Stop a measuring
+     *
+     * @return StatusEnum
+     */
+    public function finish(StatusEnum $result): StatusEnum
+    {
+        $this->calls++;
+        $this->time += microtime(true) - $this->startTime;
+
+        return $result;
+    }
+
+    /**
+     * Get total time measured in miliseconds
+     *
+     * @return float
+     */
+    public function getLoadingTime(): float
+    {
+        return $this->time * 1000;
+    }
+
+    /**
+     * Get total runs
+     *
+     * @return integer
+     */
+    public function getTotalCalls(): int
+    {
+        return $this->calls;
+    }
+}

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Backpack\Basset\Helpers;
+
+use Illuminate\Support\Facades\File;
+use PharData;
+use ZipArchive;
+
+class Unarchiver
+{
+    /**
+     * Unarchive files.
+     *
+     * @param  string  $file  source file
+     * @param  string  $output  output destination
+     * @return bool result
+     */
+    public function unarchiveFile(string $file, string $output): bool
+    {
+        $mimeType = File::mimeType($file);
+
+        switch ($mimeType) {
+            // zip
+            case 'application/zip':
+                return $this->unarchiveZip($file, $output);
+
+            // tar.gz
+            case 'application/gzip':
+            case 'application/x-gzip':
+            case 'application/bzip2':
+            case 'application/x-bzip2':
+                return $this->unarchiveGz($file, $output);
+
+            // tar
+            case 'application/x-tar':
+                return $this->unarchiveTar($file, $output);
+        }
+
+        return false;
+    }
+
+    /**
+     * Unarchive zip files.
+     *
+     * @param  string  $file  source file
+     * @param  string  $output  output destination
+     * @return bool result
+     */
+    private function unarchiveZip(string $file, string $output): bool
+    {
+        $zip = new ZipArchive();
+        $zip->open($file);
+        $result = $zip->extractTo($output);
+        $zip->close();
+
+        return $result;
+    }
+
+    /**
+     * Unarchive gz files.
+     *
+     * @param  string  $file  source file
+     * @param  string  $output  output destination
+     * @return bool result
+     */
+    private function unarchiveGz(string $file, string $output): bool
+    {
+        $phar = new PharData($file);
+        $tar = $phar->decompress()->getPath();
+
+        $result = $this->unarchiveTar($tar, $output);
+        unlink($tar);
+
+        return $result;
+    }
+
+    /**
+     * Unarchive tar files.
+     *
+     * @param  string  $file  source file
+     * @param  string  $output  output destination
+     * @return bool result
+     */
+    private function unarchiveTar(string $file, string $output): bool
+    {
+        $phar = new PharData($file);
+
+        return $phar->extractTo($output);
+    }
+
+    /**
+     * Returns a temporary file path.
+     *
+     * @return string
+     */
+    public function getTemporaryFilePath(): string
+    {
+        return tempnam(sys_get_temp_dir(), '');
+    }
+
+    /**
+     * Returns a temporary directory path.
+     *
+     * @return string
+     */
+    public function getTemporaryDirectoryPath(): string
+    {
+        $dir = storage_path('app/tmp/'.mt_rand().'/');
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+}

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -24,14 +24,14 @@ class Unarchiver
             case 'application/zip':
                 return $this->unarchiveZip($file, $output);
 
-            // tar.gz
+                // tar.gz
             case 'application/gzip':
             case 'application/x-gzip':
             case 'application/bzip2':
             case 'application/x-bzip2':
                 return $this->unarchiveGz($file, $output);
 
-            // tar
+                // tar
             case 'application/x-tar':
                 return $this->unarchiveTar($file, $output);
         }

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -24,19 +24,42 @@ class Unarchiver
             case 'application/zip':
                 return $this->unarchiveZip($file, $output);
 
-                // tar.gz
+            // tar.gz
             case 'application/gzip':
             case 'application/x-gzip':
             case 'application/bzip2':
             case 'application/x-bzip2':
                 return $this->unarchiveGz($file, $output);
 
-                // tar
+            // tar
             case 'application/x-tar':
                 return $this->unarchiveTar($file, $output);
         }
 
         return false;
+    }
+
+    /**
+     * Returns a temporary file path.
+     *
+     * @return string
+     */
+    public function getTemporaryFilePath(): string
+    {
+        return tempnam(sys_get_temp_dir(), '');
+    }
+
+    /**
+     * Returns a temporary directory path.
+     *
+     * @return string
+     */
+    public function getTemporaryDirectoryPath(): string
+    {
+        $dir = storage_path('app/tmp/'.mt_rand().'/');
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
     }
 
     /**
@@ -86,28 +109,5 @@ class Unarchiver
         $phar = new PharData($file);
 
         return $phar->extractTo($output);
-    }
-
-    /**
-     * Returns a temporary file path.
-     *
-     * @return string
-     */
-    public function getTemporaryFilePath(): string
-    {
-        return tempnam(sys_get_temp_dir(), '');
-    }
-
-    /**
-     * Returns a temporary directory path.
-     *
-     * @return string
-     */
-    public function getTemporaryDirectoryPath(): string
-    {
-        $dir = storage_path('app/tmp/'.mt_rand().'/');
-        File::ensureDirectoryExists($dir);
-
-        return $dir;
     }
 }

--- a/src/Traits/ViewPathsTrait.php
+++ b/src/Traits/ViewPathsTrait.php
@@ -2,14 +2,12 @@
 
 namespace Backpack\Basset\Traits;
 
-use Illuminate\Support\Facades\File;
-
 trait ViewPathsTrait
 {
     private static $viewPaths = [];
 
     /**
-     * Initialize view paths
+     * Initialize view paths.
      *
      * @return void
      */
@@ -21,9 +19,9 @@ trait ViewPathsTrait
     /**
      * Add a view path that may use @basset directive
      * This is used to internalize assets in advance
-     * with the command artisan basset:internalize
+     * with the command artisan basset:internalize.
      *
-     * @param string $path
+     * @param  string  $path
      * @return void
      */
     public static function addViewPath(string $path): void
@@ -34,7 +32,7 @@ trait ViewPathsTrait
     }
 
     /**
-     * Gets the current view paths
+     * Gets the current view paths.
      *
      * @return array
      */

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -11,9 +11,6 @@ return [
     // use cache map file (.basset)
     'cache_map' => true,
 
-    // cachebusting string variable that is added to all bassets
-    'cachebusting' => false,
-
     // view paths that may use @basset
     // used to internalize assets in advance with artisan basset:internalize
     'view_paths' => [

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -5,6 +5,9 @@ return [
     'disk' => 'public',
     'path' => 'basset',
 
+    // use cache map file (.basset)
+    'cache_map' => true,
+
     // cachebusting string variable that is added to all bassets
     'cachebusting' => false,
 

--- a/tests/Feature/DevModeTest.php
+++ b/tests/Feature/DevModeTest.php
@@ -10,9 +10,6 @@ it('ignores cdn basset on dev mode', function ($asset) {
     $result = basset($asset, false);
     $path = basset()->getPath($asset);
 
-    // expect the output of the asset
-    $this->expectOutputRegex("/$asset/");
-
     // assert file was not saved
     disk()->assertMissing($path);
 


### PR DESCRIPTION
This PR aims the first possible improvement on https://github.com/Laravel-Backpack/basset/issues/18 👌

I'll start this by the results;

Previous loading times in _ms_ for [demo monsters edit page](https://demo.backpackforlaravel.com/admin/monster/140/edit), >200 bassets;
> 5.3005218505859  
> 4.9705505371094  
> 5.4311752319336  

Using cache map 🤯
> 1.5203952789307  
> 1.662015914917  
> 1.467227935791  

It's 3 times faster!!! 

---

There's a new config for enabling or disabling cacheMap `'cache_map' => true`.
In order to test the loading times, there's a _hidden_ config `'log_execution_time' => true` 👌

