### PR TITLE
Cachebusting string from composer.lock hash

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -26,8 +26,7 @@ class BassetManager
         $this->loaded = [];
         $this->disk = Storage::disk(config('backpack.basset.disk'));
 
-        $cachebusting = config('backpack.basset.cachebusting');
-        $this->cachebusting = $cachebusting ? (string) Str::of($cachebusting)->start('?') : '';
+        $this->cachebusting = '?'.substr(md5(base_path('composer.lock')), 0, 12);
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');
 
         // initialize static view path methods
@@ -151,7 +150,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool | string $output = true, array $attributes = []): StatusEnum
     {
         // Get asset path
         $path = $this->getPath(is_string($output) ? $output : $asset);

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -150,7 +150,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool | string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
     {
         // Get asset path
         $path = $this->getPath(is_string($output) ? $output : $asset);

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -5,9 +5,6 @@ return [
     'disk' => 'public',
     'path' => 'basset',
 
-    // cachebusting string variable that is added to all bassets
-    'cachebusting' => false,
-
     // view paths that may use @basset
     // used to internalize assets in advance with artisan basset:internalize
     'view_paths' => [


### PR DESCRIPTION
This PR aims to fix https://github.com/Laravel-Backpack/basset/issues/17.

But;
In both production and development, cache busting string comes from composer.lock hash.
This is just an extra step to avoid cache because cache issues shouldn't come up.

For CDN assets (online) when they change, their version will change generating new urls.
For basset blocks an hash is already generated and appended to the file, so any change in the block will generate new url.