### PR TITLE
Added missing condition for dev mode

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -198,7 +198,7 @@ class BassetManager
 
         // Retrieve from map
         $mapped = $this->cacheMap->getAsset($asset);
-        if ($mapped) {
+        if ($mapped && ! $this->dev) {
             $output && $this->echoFile($mapped, $attributes);
 
             return $this->loader->finish(StatusEnum::IN_CACHE);


### PR DESCRIPTION
After adding the cache map, dev mode was not taken into consideration.

The rule should be to ignore the cache map if in dev mode ✔️
The added validation makes basset to always force the update of the files while in dev mode 👌

I noticed this issue while I was not seeing any change on the tabler `common.css` file 🤷‍♂️