### PR TITLE
Added csp nonce support

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -133,9 +133,9 @@ class BassetManager
     }
 
     /**
-     * Prepares attributes to be added to the script/style dom element
+     * Prepares attributes to be added to the script/style dom element.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return string
      */
     private function prepareAttributes(array $attributes = []): string

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -16,4 +16,7 @@ return [
     'view_paths' => [
         resource_path('views'),
     ],
+
+    // content security policy nonce
+    'nonce' => null,
 ];


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/basset/issues/35.

This PR allows to set the `nonce` in the config file:
```php
// content security policy nonce
'nonce' => '6t6s5d4fsdf2',
```

In order to print it in every script/style:
![image](https://github.com/Laravel-Backpack/basset/assets/1838187/27ec85d5-120c-4658-914b-4a11a724b32d)

If the developer doesn't need/want the nonce to be everywhere, he can either add it manually one by one, or override specific calls with another nonce.