### PR TITLE
Fixed loading of assets with query strings

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -143,7 +143,8 @@ class BassetManager
     public function getPath(string $asset): string
     {
         return Str::of($this->basePath)
-            ->append(str_replace([base_path(), 'http://', 'https://', '://', '<', '>', ':', '"', '|', '?', "\0", '*', '`', ';', "'", '+'], '', $asset))
+            ->append(str_replace([base_path(), 'http://', 'https://', '://', '<', '>', ':', '"', '|', "\0", '*', '`', ';', "'", '+'], '', $asset))
+            ->before('?')
             ->replace('/\\', '/');
     }
 
@@ -243,6 +244,12 @@ class BassetManager
 
             $content = Http::get($asset)->body();
         } else {
+            // clean local asset
+            $asset = Str::before($asset, '?');
+
+            if (! File::exists($asset)) {
+                return $this->loader->finish(StatusEnum::INVALID);
+            }
             $content = File::get($asset);
         }
 


### PR DESCRIPTION
This will remove the query string part of a URL before creating the URL.

This also fixes https://github.com/Laravel-Backpack/basset/issues/44.
Because it is now validating that the file exists.
As the file didn't exist on the system, it was throwing un ugly error and causing the section to not end.