### PR TITLE
Add PHP zip extension notes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "orchestra/testbench": "^7.22|^8.5",
         "phpstan/phpstan": "^1.10"
     },
+    "suggest": {
+        "ext-zip": "Required to use @bassetArchive with .zip archives."
+    },
     "autoload": {
         "psr-4": {
             "Backpack\\Basset\\": "src/"

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,8 @@ Basset will:
 - on all requests, use the local file (using `<script src="">`)
 - make sure that file is only loaded once per pageload
 
+*Note:* when referencing `.zip` archives, the [PHP zip extension](https://www.php.net/manual/en/book.zip.php) is required.
+
 ### Easily internalize and use entire non-public directories
 
 ```diff


### PR DESCRIPTION
When using the basset package to extract `.zip` archives, the PHP zip extension is required. This is an important note to users, since for example the default Windows installation (see https://www.php.net/manual/en/zip.installation.php#zip.installation.new.windows) and the official PHP Docker image do not enable this by default.