### PR TITLE
Fix issue with reading .tar.gz archives

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -410,7 +410,7 @@ class BassetManager
             }
 
             // temporary file
-            $file = $this->unarchiver->getTemporaryFilePath($asset);
+            $file = $this->unarchiver->getTemporaryFilePath();
 
             // download file to temporary location
             $content = Http::get($asset)->body();

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -410,7 +410,7 @@ class BassetManager
             }
 
             // temporary file
-            $file = $this->unarchiver->getTemporaryFilePath();
+            $file = $this->unarchiver->getTemporaryFilePath($asset);
 
             // download file to temporary location
             $content = Http::get($asset)->body();

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -54,7 +54,7 @@ class Unarchiver
         $path = Str::finish(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
 
         do {
-            $filename = Str::finish(Str::random(), '.tmp');
+            $filename = Str::finish(uniqid(), '.tmp');
         } while (File::exists($path . $filename));
 
         return $path . $filename;

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -43,17 +43,21 @@ class Unarchiver
     /**
      * Returns a temporary file path.
      *
-     * The original file extension is preserved so that the file can be
-     * correctly read by the PharData class in unarchiveTar() and
-     * unarchiveGz() methods.
+     * We cannot use the built-in methods for generating temporary files because
+     * in some OS, the temporary file is created without any extension and the
+     * PharData class cannot detect the file type.
      *
      * @return string
      */
-    public function getTemporaryFilePath(string $asset): string
+    public function getTemporaryFilePath(): string
     {
-        $filename = Str::random() . Str::afterLast($asset, '/');
+        $path = Str::finish(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
 
-        return sys_get_temp_dir() . $filename;
+        do {
+            $filename = Str::finish(Str::random(), '.tmp');
+        } while (File::exists($path . $filename));
+
+        return $path . $filename;
     }
 
     /**

--- a/src/Helpers/Unarchiver.php
+++ b/src/Helpers/Unarchiver.php
@@ -3,6 +3,7 @@
 namespace Backpack\Basset\Helpers;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use PharData;
 use ZipArchive;
 
@@ -24,14 +25,14 @@ class Unarchiver
             case 'application/zip':
                 return $this->unarchiveZip($file, $output);
 
-                // tar.gz
+            // tar.gz
             case 'application/gzip':
             case 'application/x-gzip':
             case 'application/bzip2':
             case 'application/x-bzip2':
                 return $this->unarchiveGz($file, $output);
 
-                // tar
+            // tar
             case 'application/x-tar':
                 return $this->unarchiveTar($file, $output);
         }
@@ -42,11 +43,17 @@ class Unarchiver
     /**
      * Returns a temporary file path.
      *
+     * The original file extension is preserved so that the file can be
+     * correctly read by the PharData class in unarchiveTar() and
+     * unarchiveGz() methods.
+     *
      * @return string
      */
-    public function getTemporaryFilePath(): string
+    public function getTemporaryFilePath(string $asset): string
     {
-        return tempnam(sys_get_temp_dir(), '');
+        $filename = Str::random() . Str::afterLast($asset, '/');
+
+        return sys_get_temp_dir() . $filename;
     }
 
     /**


### PR DESCRIPTION
This fixes the issue in reading `.tar.gz` archives by the PharData class, throwing exceptions like this: 

![image](https://github.com/Laravel-Backpack/FileManager/assets/61466274/f28b14a3-bb4f-4221-87d9-019228bfa8f5)

Fixes https://github.com/Laravel-Backpack/FileManager/issues/34.