### PR TITLE
Changed to relative paths to avoid errors with the APP_URL

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -148,7 +148,7 @@ class BassetManager
             $asset = $asset->after('//')->after('/')->start('/');
         }
 
-        return $asset->value;
+        return $asset->value();
     }
 
     /**

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -43,7 +43,7 @@ class BassetManager
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');
         $this->dev = config('backpack.basset.dev_mode', false);
         $this->nonce = config('backpack.basset.nonce', null);
-        $this->useRelativePaths = config('backpack.basset.relative_paths', false);
+        $this->useRelativePaths = config('backpack.basset.relative_paths', true);
 
         $this->cacheMap = new CacheMap($this->disk, $this->basePath);
         $this->loader = new LoadingTime();

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -25,6 +25,7 @@ class BassetManager
     private string $cachebusting;
     private string|null $nonce;
     private bool $dev = false;
+    private bool $useRelativePaths = true;
 
     public CacheMap $cacheMap;
     public LoadingTime $loader;
@@ -42,6 +43,7 @@ class BassetManager
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');
         $this->dev = config('backpack.basset.dev_mode', false);
         $this->nonce = config('backpack.basset.nonce', null);
+        $this->useRelativePaths = config('backpack.basset.relative_paths', true);
 
         $this->cacheMap = new CacheMap($this->disk, $this->basePath);
         $this->loader = new LoadingTime();
@@ -112,7 +114,7 @@ class BassetManager
      */
     public function echoCss(string $path, array $attributes = []): void
     {
-        $href = asset($path.$this->cachebusting);
+        $href = $this->assetPath($path);
         $args = $this->prepareAttributes($attributes);
 
         echo '<link href="'.$href.'"'.$args.' rel="stylesheet" type="text/css" />'.PHP_EOL;
@@ -126,10 +128,27 @@ class BassetManager
      */
     public function echoJs(string $path, array $attributes = []): void
     {
-        $src = asset($path.$this->cachebusting);
+        $src = $this->assetPath($path);
         $args = $this->prepareAttributes($attributes);
 
         echo '<script src="'.$src.'"'.$args.'></script>'.PHP_EOL;
+    }
+
+    /**
+     * Generates the asset path
+     *
+     * @param string $path
+     * @return string
+     */
+    public function assetPath(string $path): string
+    {
+        $asset = asset($path.$this->cachebusting);
+
+        if ($this->useRelativePaths) {
+            $asset = str_replace(url(''), '', $asset);
+        }
+
+        return $asset;
     }
 
     /**
@@ -202,7 +221,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool | string $output = true, array $attributes = []): StatusEnum
     {
         $this->loader->start();
 
@@ -353,8 +372,8 @@ class BassetManager
         $pattern = '\/'.Str::afterLast(preg_replace('/\w{8}\.(css|js)$/i', '\w{8}.$1', $path), '/');
 
         collect($this->disk->files($dir))
-            ->filter(fn ($file) => $file !== $path && preg_match("/$pattern/", $file))
-            ->each(fn ($file) => $this->disk->delete($file));
+            ->filter(fn($file) => $file !== $path && preg_match("/$pattern/", $file))
+            ->each(fn($file) => $this->disk->delete($file));
 
         // Output result
         if ($result) {

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -43,7 +43,7 @@ class BassetManager
         $this->basePath = (string) Str::of(config('backpack.basset.path'))->finish('/');
         $this->dev = config('backpack.basset.dev_mode', false);
         $this->nonce = config('backpack.basset.nonce', null);
-        $this->useRelativePaths = config('backpack.basset.relative_paths', true);
+        $this->useRelativePaths = config('backpack.basset.relative_paths', false);
 
         $this->cacheMap = new CacheMap($this->disk, $this->basePath);
         $this->loader = new LoadingTime();

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -142,13 +142,13 @@ class BassetManager
      */
     public function assetPath(string $path): string
     {
-        $asset = asset($path.$this->cachebusting);
+        $asset = Str::of(asset($path.$this->cachebusting));
 
-        if ($this->useRelativePaths) {
-            $asset = str_replace(url(''), '', $asset);
+        if ($this->useRelativePaths && $asset->startsWith(url(''))) {
+            $asset = $asset->after('//')->after('/')->start('/');
         }
 
-        return $asset;
+        return $asset->value;
     }
 
     /**

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -57,7 +57,7 @@ class CacheMap
      * @param  string  $path
      * @return void
      */
-    public function addAsset(string $asset, string|bool $path = true): void
+    public function addAsset(string $asset, string | bool $path = true): void
     {
         if (! $this->isActive) {
             return;
@@ -76,7 +76,7 @@ class CacheMap
      * @param  string  $asset
      * @return string | false
      */
-    public function getAsset(string $asset): string|false
+    public function getAsset(string $asset): string | false
     {
         // Clean asset path
         $asset = $this->normalizeAsset($asset);
@@ -85,7 +85,7 @@ class CacheMap
             return false;
         }
 
-        return $this->disk->url($this->basePath.$this->map[$asset]);
+        return $this->disk->url(rtrim($this->basePath, '/').$this->map[$asset]);
     }
 
     /**

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -21,5 +21,5 @@ return [
     'nonce' => null,
 
     // use relative path
-    'relative_paths' => false,
+    'relative_paths' => env('BASSET_RELATIVE_PATHS', true),
 ];

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -19,4 +19,7 @@ return [
 
     // content security policy nonce
     'nonce' => null,
+
+    // use relative path
+    'relative_paths' => false,
 ];


### PR DESCRIPTION
This aims to fix https://github.com/Laravel-Backpack/CRUD/issues/5127.

It's not the ideal fix, but this will avoid the usage of `APP_URL` by `asset()`.

Generated paths are now relative;
![image](https://github.com/Laravel-Backpack/basset/assets/1838187/db51dfaa-1f1c-4793-94b9-490e659e8de1)

Side note;
@pxpm I'm happy to tell you that this PR also fixes the last double slash issue 😅

---

**Why isn't this the ideal fix?**
> Because this may cause issues for developers running Laravel inside a folder, having APP_URL set to `http://localhost/myapp`, paths should be like `http://localhost/myapp/style.css` but will be `/style.css` instead. Since the browser will try to fetch them from the website root, it falls back to `http://localhost/style.css` that does not exist.

**Is there a solution for those cases?**
> Yes! Those extreme cases can disable the relative paths on configs or env.