### PR TITLE
Fix basset fresh concurrent calls — Drop L9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2]
-        laravel: [^9.0, ^10.0]
+        laravel: [^10.0]
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2]
-        laravel: [^10.0]
+        laravel: [^10.7]
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "analyse": "./vendor/bin/phpstan analyse --level 5 src"
     },
     "require": {
-        "laravel/framework": "^10.1",
+        "laravel/framework": "^10.7",
         "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "analyse": "./vendor/bin/phpstan analyse --level 5 src"
     },
     "require": {
-        "laravel/framework": "^10.1|^9.0",
+        "laravel/framework": "^10.1",
         "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {

--- a/src/Console/Commands/BassetFresh.php
+++ b/src/Console/Commands/BassetFresh.php
@@ -3,6 +3,7 @@
 namespace Backpack\Basset\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
 
 /**
  * Basset Fresh command.
@@ -32,7 +33,9 @@ class BassetFresh extends Command
      */
     public function handle(): void
     {
-        $this->call('basset:clear');
-        $this->call('basset:cache');
+        Process::pipe([
+            'php artisan basset:clear',
+            'php artisan basset:cache',
+        ]);
     }
 }


### PR DESCRIPTION
@pxpm you were right, `\Illuminate\Support\Facades\Process` fixes it 👌

---
_Edit_

**Not so fast 🙃**

```
Call to static method pipe() on an unknown class Illuminate\Support\Facades\Process.
```

PHP 8.1 / Laravel ^9.0 do not support Process 😔
@pxpm any idea how to overcome this?

---
_2nd Edit_

Dropping support to L9 👌