### PR TITLE
Allow install command to run without `basset:check`

### DIFF
--- a/src/Console/Commands/BassetInstall.php
+++ b/src/Console/Commands/BassetInstall.php
@@ -40,7 +40,7 @@ class BassetInstall extends Command
         // create symlink
         $this->createSymLink();
 
-        if(! $this->option('no-check')) {
+        if (! $this->option('no-check')) {
             $this->checkBasset();
         }
 

--- a/src/Console/Commands/BassetInstall.php
+++ b/src/Console/Commands/BassetInstall.php
@@ -19,7 +19,7 @@ class BassetInstall extends Command
      *
      * @var string
      */
-    protected $signature = 'basset:install';
+    protected $signature = 'basset:install {--no-check} : As the name says, `basset:check` will not run.';
 
     /**
      * The console command description.
@@ -40,8 +40,9 @@ class BassetInstall extends Command
         // create symlink
         $this->createSymLink();
 
-        // create symlink
-        $this->checkBasset();
+        if(! $this->option('no-check')) {
+            $this->checkBasset();
+        }
 
         // check if artisan storage:link command exists
         $this->addComposerCommand();


### PR DESCRIPTION
This still run the check command by default, but there is an option now that we will use in the CRUD installer script to don't run the checks immediately upon installation.