### PR TITLE
[FEATURE] Added BassetCachedEvent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,10 @@ php artisan basset:clear         # clears the basset directory
 
 In order to speed up the first page load on production, we recommend you to add `php artisan basset:cache` command to your deploy script.
 
+### Basset Cached Event
+
+If you require customized behavior after each asset is cached, you can set up a listener for the `BassetCachedEvent` in your `EventServiceProvider`. This event will be triggered each time an asset is cached.
+
 ## Configuration
 
 Take a look at [the config file](https://github.com/Laravel-Backpack/basset/blob/main/src/config/backpack/basset.php) for all configuration options. Notice some of those configs also have ENV variables, so you can:

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -3,6 +3,7 @@
 namespace Backpack\Basset;
 
 use Backpack\Basset\Enums\StatusEnum;
+use Backpack\Basset\Events\BassetCachedEvent;
 use Backpack\Basset\Helpers\CacheMap;
 use Backpack\Basset\Helpers\LoadingTime;
 use Backpack\Basset\Helpers\Unarchiver;
@@ -299,6 +300,7 @@ class BassetManager
             $output && $this->echoFile($url, $attributes);
             $this->cacheMap->addAsset($asset, $url);
 
+            BassetCachedEvent::dispatch($asset);
             return $this->loader->finish(StatusEnum::INTERNALIZED);
         }
 
@@ -380,6 +382,7 @@ class BassetManager
             $output && $this->echoFile($url);
             $this->cacheMap->addAsset($asset, $url);
 
+            BassetCachedEvent::dispatch($asset);
             return $this->loader->finish(StatusEnum::INTERNALIZED);
         }
 
@@ -461,6 +464,7 @@ class BassetManager
         File::delete($tempDir);
         $this->cacheMap->addAsset($asset);
 
+        BassetCachedEvent::dispatch($asset);
         return $this->loader->finish(StatusEnum::INTERNALIZED);
     }
 
@@ -510,6 +514,7 @@ class BassetManager
 
         $this->cacheMap->addAsset($asset);
 
+        BassetCachedEvent::dispatch($asset);
         return $this->loader->finish(StatusEnum::INTERNALIZED);
     }
 }

--- a/src/Events/BassetCachedEvent.php
+++ b/src/Events/BassetCachedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Backpack\Basset\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BassetCachedEvent
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $asset,
+    ) {}
+}


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/basset/issues/65.

This will make basset trigger an event every time an asset is cached, that should happen only one time per asset 👌

It will allow developer to listen for the event;

```php
class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        BassetCachedEvent::class => [
            BassetCachedEventListener::class,
        ],
    ];
```

and do whatever magic they need 👌

```php
namespace App\Listeners;

use Backpack\Basset\Events\BassetCachedEvent;
use Illuminate\Support\Facades\Log;

class BassetCachedEventListener
{
    public function handle(BassetCachedEvent $event): void
    {
        $url = app('basset')->getUrl($event->asset);

        Log::info("$event->asset file was cached, its url is $url.");
    }
}
```