### PR TITLE
Avoid to verify SSL on local

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -515,9 +515,6 @@ class BassetManager
 
     /**
      * Fetch the content body of an url.
-     *
-     * @param  string  $url
-     * @return string
      */
     public function fetchContent(string $url): string
     {

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -279,7 +279,7 @@ class BassetManager
                 return $this->loader->finish(StatusEnum::DISABLED);
             }
 
-            $content = Http::get($asset)->body();
+            $content = $this->fetchContent($asset);
         } else {
             // clean local asset
             $asset = Str::before($asset, '?');
@@ -432,7 +432,7 @@ class BassetManager
             $file = $this->unarchiver->getTemporaryFilePath();
 
             // download file to temporary location
-            $content = Http::get($asset)->body();
+            $content = $this->fetchContent($asset);
             File::put($file, $content);
         }
 
@@ -511,5 +511,18 @@ class BassetManager
         $this->cacheMap->addAsset($asset);
 
         return $this->loader->finish(StatusEnum::INTERNALIZED);
+    }
+
+    /**
+     * Fetch the content body of an url
+     *
+     * @param string $url
+     * @return string
+     */
+    public function fetchContent(string $url): string
+    {
+        return Http::withOptions(['verify' => ! config('backpack.basset.dev_mode')])
+            ->get($url)
+            ->body();
     }
 }

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -514,9 +514,9 @@ class BassetManager
     }
 
     /**
-     * Fetch the content body of an url
+     * Fetch the content body of an url.
      *
-     * @param string $url
+     * @param  string  $url
      * @return string
      */
     public function fetchContent(string $url): string

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -521,7 +521,7 @@ class BassetManager
      */
     public function fetchContent(string $url): string
     {
-        return Http::withOptions(['verify' => ! config('backpack.basset.dev_mode')])
+        return Http::withOptions(['verify' => config('backpack.basset.verify_ssl_certificate', true)])
             ->get($url)
             ->body();
     }

--- a/src/Console/Commands/BassetCheck.php
+++ b/src/Console/Commands/BassetCheck.php
@@ -132,9 +132,9 @@ class BassetCheck extends Command
             $url = url($url);
         }
 
-        $result = Http::get($url);
+        $result = $this->basset->fetchContent($url);
 
-        if ($result->body() !== 'test') {
+        if ($result !== 'test') {
             throw new Exception('Error fetching the file.');
         }
     }

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -4,6 +4,9 @@ return [
     // development mode, assets will not be internalized
     'dev_mode' => env('BASSET_DEV_MODE', env('APP_ENV') === 'local'),
 
+    // verify ssl certificate while fetching assets
+    'verify_ssl_certificate' => true,
+
     // disk and path where to store bassets
     'disk' => env('BASSET_DISK', 'public'),
     'path' => 'basset',

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -5,7 +5,7 @@ return [
     'dev_mode' => env('BASSET_DEV_MODE', env('APP_ENV') === 'local'),
 
     // verify ssl certificate while fetching assets
-    'verify_ssl_certificate' => true,
+    'verify_ssl_certificate' => env('BASSET_VERIFY_SSL_CERTIFICATE', true),
 
     // disk and path where to store bassets
     'disk' => env('BASSET_DISK', 'public'),


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/basset/issues/95.

This is a fix for local development where developers use self signed certificates (like the ones provided by Laragon or similar).

`ERROR - cURL error 60: SSL certificate problem: self signed certificate (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://backpack.test/storage/basset/vendor/backpack/basset/tests/Helpers/basset-test.js.`

This will make the HTTP to now verify the requests when `dev_mode === true`.