### PR TITLE
[Bug] Reorder basset block checks

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -319,13 +319,6 @@ class BassetManager
     {
         $this->loader->start();
 
-        // fallback to code on dev mode
-        if ($this->dev) {
-            echo $code;
-
-            return $this->loader->finish(StatusEnum::DISABLED);
-        }
-
         // Get asset path and url
         $path = $this->getPathHashed($asset, $code);
 
@@ -334,6 +327,13 @@ class BassetManager
         }
 
         $this->markAsLoaded($path);
+
+        // fallback to code on dev mode
+        if ($this->dev) {
+            echo $code;
+
+            return $this->loader->finish(StatusEnum::DISABLED);
+        }
 
         // Retrieve from map
         $mapped = $this->cacheMap->getAsset($asset);


### PR DESCRIPTION
The check if the script is already loaded should come first to avoid injecting same script multiple times in the page.

This bug was only happening with basset blocks, while on dev mode.