### PR TITLE
Load BassetManager via Scoped Singleton to resolve Octane issues

### DIFF
--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -69,7 +69,7 @@ class BassetServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Register the service the package provides.
-        $this->app->singleton('basset', fn () => new BassetManager());
+        $this->app->scoped('basset', fn () => new BassetManager());
 
         // Merge the configuration file.
         $this->mergeConfigFrom(__DIR__.'/config/backpack/basset.php', 'backpack.basset');


### PR DESCRIPTION
As highlighted in this issue, using the Octane runtime causes assets not to load after the first request

https://github.com/Laravel-Backpack/basset/issues/102

Binding using a singleton when using Octane can cause problems across requests. Binding using a scoped singleton will resolve this behaviour on Octane but won't negatively affect php-fpm users

See Laravel Docs:

https://laravel.com/docs/10.x/container#binding-scoped