### PR TITLE
Update BassetInstall to use provided PHP process

### DIFF
--- a/src/Console/Commands/BassetInstall.php
+++ b/src/Console/Commands/BassetInstall.php
@@ -104,7 +104,7 @@ class BassetInstall extends Command
 
         if ($this->components->confirm('You will need to run `php artisan storage:link` on every server you deploy the app to. Do you wish to add that command to composer.json\' post-install-script, to make that automatic?', true)) {
             $this->components->task($message, function () {
-                $process = new Process(['composer', 'config', 'scripts.post-install-cmd.-1', 'php artisan storage:link --quiet']);
+                $process = new Process(['composer', 'config', 'scripts.post-install-cmd.-1', '@php artisan storage:link --quiet']);
                 $process->run();
             });
         }


### PR DESCRIPTION
### Story
While deploying a new app on a shared hosting (has PHP 7.4 in CLI, PHP 8.1 inside the served app), I noticed an issue - the command from `"post-install-cmd": ["php artisan storage:link --quiet"]` fails, complaining that Composer expects PHP 8.1, but PHP is version 7.4.
The command I execute is `/opt/cpanel/php81/root/usr/bin/php composer install` which explicitly uses PHP 8.1 for executing the composer install. But it is ignored by `php artisan storage:link --quiet`,which uses the default PHP 7.4 instead of the one I explicitly specified.

### Proposed fix
Prefix the command with `@`.

Proof of similar usage:

1. The [composer.json](https://github.com/laravel/laravel/blob/10.x/composer.json) that comes with Laravel uses `@php` instead of `php`.
2. The official composer [documentation](https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts) about executing PHP scripts

### Warning
This is currently not an issue and with composer commands provided in an array format this will not be an issue, but worth mentioning:
> One limitation of this is that you can not call multiple commands in a row like `@php install && @php foo`. You must split them up in a JSON array of commands.