### PR TITLE
Allow to set/force the extension of the asset

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -134,7 +134,7 @@ class BassetManager
      * @param  array  $attributes
      * @return StatusEnum
      */
-    public function basset(string $asset, bool|string $output = true, array $attributes = []): StatusEnum
+    public function basset(string $asset, bool|string $output = true, array $attributes = [], string $extension = null): StatusEnum
     {
         $this->loader->start();
 
@@ -150,7 +150,7 @@ class BassetManager
         // Retrieve from map
         $mapped = $this->cacheMap->getAsset($asset);
         if ($mapped && ! $this->dev) {
-            $output && $this->output->write($mapped, $attributes);
+            $output && $this->output->write($mapped, $attributes, $extension);
 
             return $this->loader->finish(StatusEnum::IN_CACHE);
         }
@@ -160,13 +160,13 @@ class BassetManager
             // may be an internalized asset (folder or zip)
             if ($this->disk->exists($path)) {
                 $asset = $this->disk->url($path);
-                $output && $this->output->write($asset, $attributes);
+                $output && $this->output->write($asset, $attributes, $extension);
 
                 return $this->loader->finish(StatusEnum::IN_CACHE);
             }
 
             // public file (default fallback)
-            $output && $this->output->write($asset, $attributes);
+            $output && $this->output->write($asset, $attributes, $extension);
 
             return $this->loader->finish(StatusEnum::INVALID);
         }
@@ -177,7 +177,7 @@ class BassetManager
         // Check if asset exists in basset folder
         // (ignores cache if in dev mode)
         if ($this->disk->exists($path) && ! $this->dev) {
-            $output && $this->output->write($url, $attributes);
+            $output && $this->output->write($url, $attributes, $extension);
             $this->cacheMap->addAsset($asset, $url);
 
             return $this->loader->finish(StatusEnum::IN_CACHE);
@@ -187,7 +187,7 @@ class BassetManager
         if (Str::isUrl($asset)) {
             // when in dev mode, cdn should be rendered
             if ($this->dev) {
-                $output && $this->output->write($asset, $attributes);
+                $output && $this->output->write($asset, $attributes, $extension);
 
                 return $this->loader->finish(StatusEnum::DISABLED);
             }
@@ -209,14 +209,14 @@ class BassetManager
         $result = $this->disk->put($path, $content, 'public');
 
         if ($result) {
-            $output && $this->output->write($url, $attributes);
+            $output && $this->output->write($url, $attributes, $extension);
             $this->cacheMap->addAsset($asset, $url);
 
             return $this->loader->finish(StatusEnum::INTERNALIZED);
         }
 
         // Fallback to the CDN/path
-        $output && $this->output->write($asset, $attributes);
+        $output && $this->output->write($asset, $attributes, $extension);
 
         return $this->loader->finish(StatusEnum::INVALID);
     }

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -34,9 +34,9 @@ class FileOutput
      * @param  array  $attributes
      * @return void
      */
-    public function write(string $path, array $attributes = []): void
+    public function write(string $path, array $attributes = [], string $extension = null): void
     {
-        $extension = (string) Str::of($path)->afterLast('.');
+        $extension ??= (string) Str::of($path)->afterLast('.');
 
         // map extensions
         $file = match ($extension) {


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/basset/issues/103.

This allows developers to set/force the extension of an asset, in case of Tailwind (https://cdn.tailwindcss.com/3.4.3) which has no extension, developers can force it to be rendered as a `js`.