### PR TITLE
store the file with the provided extension

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -21,13 +21,19 @@ class BassetManager
     use Traits\ViewPathsTrait;
 
     private FilesystemAdapter $disk;
+
     private array $loaded;
+
     private string $basePath;
+
     private bool $dev = false;
 
     public CacheMap $cacheMap;
+
     public LoadingTime $loader;
+
     public Unarchiver $unarchiver;
+
     public FileOutput $output;
 
     public function __construct()
@@ -90,12 +96,13 @@ class BassetManager
      * @param  string  $asset
      * @return string
      */
-    public function getPath(string $asset): string
+    public function getPath(string $asset, string $extension = null): string
     {
         return Str::of($this->basePath)
             ->append(str_replace([base_path().'/', base_path(), 'http://', 'https://', '://', '<', '>', ':', '"', '|', "\0", '*', '`', ';', "'", '+'], '', $asset))
             ->before('?')
-            ->replace('/\\', '/');
+            ->replace('/\\', '/')
+            ->finish($extension ?? '');
     }
 
     /**
@@ -138,8 +145,10 @@ class BassetManager
     {
         $this->loader->start();
 
+        $extension = empty($extension) ? $extension : Str::start($extension, '.');
+
         // Get asset path
-        $path = $this->getPath(is_string($output) ? $output : $asset);
+        $path = $this->getPath(is_string($output) ? $output : $asset, $extension);
 
         if ($this->isLoaded($path)) {
             return $this->loader->finish(StatusEnum::LOADED);

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -21,19 +21,13 @@ class BassetManager
     use Traits\ViewPathsTrait;
 
     private FilesystemAdapter $disk;
-
     private array $loaded;
-
     private string $basePath;
-
     private bool $dev = false;
 
     public CacheMap $cacheMap;
-
     public LoadingTime $loader;
-
     public Unarchiver $unarchiver;
-
     public FileOutput $output;
 
     public function __construct()
@@ -145,7 +139,9 @@ class BassetManager
     {
         $this->loader->start();
 
-        $extension = empty($extension) ? $extension : Str::start($extension, '.');
+        if ($extension) {
+            $extension = Str::start($extension, '.');
+        }
 
         // Get asset path
         $path = $this->getPath(is_string($output) ? $output : $asset, $extension);

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -28,7 +28,7 @@ class CacheMap
 
         // Load map
         if (File::exists($this->filePath)) {
-            $this->map = json_decode(File::get($this->filePath), true);
+            $this->map = json_decode(File::get($this->filePath), true) ?? [];
         }
     }
 

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -36,8 +36,8 @@ class FileOutput
      */
     public function write(string $path, array $attributes = [], string $extension = null): void
     {
-        $extension ??= (string) Str::of($path)->afterLast('.');
-        $extension = Str::afterLast($extension, '.');
+        $extension ??= (string) Str::afterLast($extension, '.');
+
         // map extensions
         $file = match ($extension) {
             'jpg', 'jpeg', 'png', 'webp', 'gif', 'svg' => 'img',
@@ -53,7 +53,7 @@ class FileOutput
             return;
         }
 
-        $path = Str::of($path)->finish('.'.$extension);
+        $path = (string) Str::finish($path, '.'.$extension);
         echo Blade::render($template, [
             'src' => $this->assetPath($path),
             'args' => $this->prepareAttributes($attributes),

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -37,7 +37,7 @@ class FileOutput
     public function write(string $path, array $attributes = [], string $extension = null): void
     {
         $extension ??= (string) Str::of($path)->afterLast('.');
-
+        $extension = Str::afterLast($extension, '.');
         // map extensions
         $file = match ($extension) {
             'jpg', 'jpeg', 'png', 'webp', 'gif', 'svg' => 'img',
@@ -53,6 +53,7 @@ class FileOutput
             return;
         }
 
+        $path = Str::of($path)->finish('.'.$extension);
         echo Blade::render($template, [
             'src' => $this->assetPath($path),
             'args' => $this->prepareAttributes($attributes),

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -36,7 +36,7 @@ class FileOutput
      */
     public function write(string $path, array $attributes = [], string $extension = null): void
     {
-        $extension ??= (string) Str::afterLast($extension, '.');
+        $extension ??= (string) Str::of($path)->afterLast('.');
 
         // map extensions
         $file = match ($extension) {
@@ -53,7 +53,7 @@ class FileOutput
             return;
         }
 
-        $path = (string) Str::finish($path, '.'.$extension);
+        $path = (string) Str::of($path)->finish('.'.$extension);
         echo Blade::render($template, [
             'src' => $this->assetPath($path),
             'args' => $this->prepareAttributes($attributes),


### PR DESCRIPTION
Hey @promatik 

Like we discussed, I am not sure if there are any security/permission etc implications by saving files without extension, but even if not from those perspectives, I think there are some benefits on storing the file with the extension and no downsides.

When you look at the basset folder, you immediately know the type of file. 
![image](https://github.com/Laravel-Backpack/basset/assets/7188159/fb05cdb6-98f8-4d1c-8106-5c3c333743e9)
VS
![image](https://github.com/Laravel-Backpack/basset/assets/7188159/478c9011-9df5-4657-ae2e-a69fbc2dae4a)

I think I didn't miss nothing, but please review and let me now. This points to #117 