### PR TITLE
add back the cache string for ALL assets

### DIFF
--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -70,12 +70,7 @@ class FileOutput
      */
     public function assetPath(string $path): string
     {
-        // if path is not a url or it's local url, we will append the cachebusting
-        if (! Str::startsWith($path, ['http://', 'https://', '://']) || Str::startsWith($path, url(''))) {
-            $path .= $this->cachebusting;
-        }
-
-        $asset = Str::of(asset($path));
+        $asset = Str::of(asset($path.$this->cachebusting));
 
         if ($this->useRelativePaths && $asset->startsWith(url(''))) {
             $asset = $asset->after('//')->after('/')->start('/');


### PR DESCRIPTION
This reverts #120 

After talking with @tabacitu we decided that we should revert this change to avoid possible braking changes with non-cdn urls. 

Apparently the issue was not the cache-busting string, was the cdn outage in general that prevent assets from loading. 

