### PR TITLE
Fix @loadOnce directive

### DIFF
--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -110,7 +110,7 @@ class BassetServiceProvider extends ServiceProvider
                 return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean()); ?>';
             });
 
-            // DEPRECATED - Please use `@basset`. Will be completely removed in Backpack v7.
+            // DEPRECATED - Please use `@basset` or `@bassetBlock`. @loadOnce Will be completely removed in Backpack v7.
             $bladeCompiler->directive('loadOnce', function (string $parameter): string {
                 // determine if it's a CSS or JS file
                 $cleanParameter = Str::of($parameter)->trim("'")->trim('"')->trim('`');
@@ -119,9 +119,13 @@ class BassetServiceProvider extends ServiceProvider
                 if (Str::endsWith($filePath, ['.js', '.css'])) {
                     return "<?php Basset::basset({$parameter}); ?>";
                 }
-
-                // in case it's not js or css, we assume it's a block of code.
-                return "<?php \$bassetBlock = {$parameter}; ob_start(); ?>";
+                
+                // in case it's not js or css specifically, we assume it's a block of javascript code.
+                // this is to keep backward compatibility with our previous usage of @loadOnce to load blocks of JS. 
+                // we never used it for css and the recommended way was always to @loadOnce(file.css) or @loadOnce(file.js)
+                // this is a temporary solution until we remove @loadOnce completely.
+                $filePath = Str::of($filePath)->finish('.js')->value();
+                return "<?php \$bassetBlock = '{$filePath}'; ob_start(); ?>";
             });
 
             $bladeCompiler->directive('endLoadOnce', function (): string {

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -119,12 +119,13 @@ class BassetServiceProvider extends ServiceProvider
                 if (Str::endsWith($filePath, ['.js', '.css'])) {
                     return "<?php Basset::basset({$parameter}); ?>";
                 }
-                
+
                 // in case it's not js or css specifically, we assume it's a block of javascript code.
-                // this is to keep backward compatibility with our previous usage of @loadOnce to load blocks of JS. 
+                // this is to keep backward compatibility with our previous usage of @loadOnce to load blocks of JS.
                 // we never used it for css and the recommended way was always to @loadOnce(file.css) or @loadOnce(file.js)
                 // this is a temporary solution until we remove @loadOnce completely.
                 $filePath = Str::of($filePath)->finish('.js')->value();
+
                 return "<?php \$bassetBlock = '{$filePath}'; ob_start(); ?>";
             });
 

--- a/src/Console/Commands/BassetCache.php
+++ b/src/Console/Commands/BassetCache.php
@@ -40,6 +40,9 @@ class BassetCache extends Command
     public function handle(): void
     {
         $starttime = microtime(true);
+        /**
+         * @var \Backpack\Basset\BassetManager $basset
+         */
         $basset = app('basset');
 
         $viewPaths = $basset->getViewPaths();


### PR DESCRIPTION
Some weeks ago I fixed a broken compatibility of basset with @loadOnce directives in #122 

That fixed the reported issue but left other cases un-handled, like @loadOnce blocks. 

A search across our repos, I see we left some @loadOnce behind in PRO package. https://github.com/search?q=org%3ALaravel-Backpack+%40loadOnce%28&type=code

In some way, it kind of makes sense having some @loadOnce, since we didn't tell users to remove the loadOnce and use @basset as we did for most of our code, people who had published files with @loadOnce would expect them to still work. 

As you see we only use @loadOnce for blocks of javascript, ence this fix is targeted at that. To expand the scope of this to support either css or js like bassetBlock does, we would need to parse the `buffer` (ob_get_clean()) and maybe search for `<script>` or `<style>` tags. 

I could have also changed the @loadOnce directives we have in our code to @bassetBlocks, but that would still be a BC for users that have published those buttons before.

I think this gives us the better compatibility until we remove loadOnce completely in next version as we should have done when launching basset. 🤷 it is what it is. 