### PR TITLE
Allow basset blocks to skip cache

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -231,9 +231,22 @@ class BassetManager
      * @param  string  $code
      * @return StatusEnum
      */
-    public function bassetBlock(string $asset, string $code, bool $output = true): StatusEnum
+    public function bassetBlock(string $asset, string $code, bool $output = true, bool $cache = true): StatusEnum
     {
         $this->loader->start();
+
+        // when cache is set to false we will just mark the asset as loaded to avoid
+        // loading the same asset twice and return the raw code to the browser.
+        if($cache === false) {
+            if($this->isloaded($asset)) {
+                return $this->loader->finish(StatusEnum::LOADED);
+            }
+            $this->markAsLoaded($asset);
+            
+            echo $code;
+
+            return $this->loader->finish(StatusEnum::LOADED);
+        }
 
         // Get asset path and url
         $path = $this->getPathHashed($asset, $code);

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -237,12 +237,12 @@ class BassetManager
 
         // when cache is set to false we will just mark the asset as loaded to avoid
         // loading the same asset twice and return the raw code to the browser.
-        if($cache === false) {
-            if($this->isloaded($asset)) {
+        if ($cache === false) {
+            if ($this->isloaded($asset)) {
                 return $this->loader->finish(StatusEnum::LOADED);
             }
             $this->markAsLoaded($asset);
-            
+
             echo $code;
 
             return $this->loader->finish(StatusEnum::LOADED);

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -103,16 +103,11 @@ class BassetServiceProvider extends ServiceProvider
 
             // Basset Code Block
             $bladeCompiler->directive('bassetBlock', function (string $parameter): string {
-                $parameters = array_map('trim', explode(',', $parameter));
-                $blockName = $parameters[0];
-                // keep cache as true by default when not provided in block definition
-                $cacheOption = $parameters[1] ?? true;
-
-                return "<?php \$bassetBlock = {$blockName}; \$cache = {$cacheOption}; ob_start(); ?>";
+                return "<?php \$bassetBlock = {$parameter}; ob_start(); ?>";
             });
 
             $bladeCompiler->directive('endBassetBlock', function (): string {
-                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean(), true, $cache); ?>';
+                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean()); ?>';
             });
 
             // DEPRECATED - Please use `@basset` or `@bassetBlock`. @loadOnce Will be completely removed in Backpack v7.
@@ -135,7 +130,7 @@ class BassetServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('endLoadOnce', function (): string {
-                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean()); ?>';
+                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean(), true, false); ?>';
             });
 
             $bladeCompiler->directive('loadStyleOnce', function (string $parameter): string {

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -107,7 +107,7 @@ class BassetServiceProvider extends ServiceProvider
                 $blockName = $parameters[0];
                 // keep cache as true by default when not provided in block definition
                 $cacheOption = $parameters[1] ?? true;
-               
+
                 return "<?php \$bassetBlock = {$blockName}; \$cache = {$cacheOption}; ob_start(); ?>";
             });
 

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -103,11 +103,16 @@ class BassetServiceProvider extends ServiceProvider
 
             // Basset Code Block
             $bladeCompiler->directive('bassetBlock', function (string $parameter): string {
-                return "<?php \$bassetBlock = {$parameter}; ob_start(); ?>";
+                $parameters = array_map('trim', explode(',', $parameter));
+                $blockName = $parameters[0];
+                // keep cache as true by default when not provided in block definition
+                $cacheOption = $parameters[1] ?? true;
+               
+                return "<?php \$bassetBlock = {$blockName}; \$cache = {$cacheOption}; ob_start(); ?>";
             });
 
             $bladeCompiler->directive('endBassetBlock', function (): string {
-                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean()); ?>';
+                return '<?php Basset::bassetBlock($bassetBlock, ob_get_clean(), true, $cache); ?>';
             });
 
             // DEPRECATED - Please use `@basset` or `@bassetBlock`. @loadOnce Will be completely removed in Backpack v7.

--- a/tests/Feature/BassetTest.php
+++ b/tests/Feature/BassetTest.php
@@ -4,7 +4,7 @@ use Backpack\Basset\Enums\StatusEnum;
 use Illuminate\Support\Facades\Http;
 
 test('confirm environment is set to testing', function () {
-    expect(config('app.env'))->toBe('testing');
+    expect(config('app.env'))->toBe('workbench');
 });
 
 it('fails on invalid path', function () {


### PR DESCRIPTION
There was no way to just tell basset: "here, have this code, just don't display it twice on page without modifications". 

Basset would always get the code, do some parsing like removing tags, trims, etc and store the output to a file. 

It would work "most" of the time, but in cases were you want to load a script from a remote url at run-time (like google maps script), all the basset work under the hood would prevent it from working properly. 

Using `@basset(maps script url)` could also be viable if there was a way to don't cache that in a file like I did here for `@bassetBlock`.

The reason I did it for `@bassetBlock` only and not for `@basset` is because I believe `bassetBlocks()` should never be cached to other files. They already exist in our application where we wrote them, we just want to ensure they are not displayed twice on the page, that's why we put them inside a `@bassetBlock`. Moving them to a separate file "just because" is a big overhead and IMO we should remove that behavior in Basset v2. 

The `@bassetBlock('block-ident,js', true)` directive now accepts a second argument to control the previously described behavior. When the second argume (cache) is `false`, basset will not do any of his work, just mark the "block" as loaded and return the code as is. This ensures the script is not loaded twice on page or is modified by basset. 