### PR TITLE
Update BassetManager.php temporary folder delete logic

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -395,7 +395,7 @@ class BassetManager
             }
         }
         // delete the whole temporary folder
-        File::delete($tempDir);
+        File::deleteDirectory($tempDir);
 
         $this->cacheMap->addAsset($asset);
 


### PR DESCRIPTION
Modified the temporary folder delete logic to use File::deleteDirectory over File:delete as it was silently failing:

<img width="251" alt="Screenshot 2024-08-27 at 12 11 44 PM" src="https://github.com/user-attachments/assets/1860ddbd-da6c-4e53-8789-6c0ab8a7c376">

This causes the temporary folders to remain, and take up space.

