### PR TITLE
fixes asset relative paths

### DIFF
--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -70,7 +70,7 @@ class FileOutput
      */
     public function assetPath(string $path): string
     {
-        $asset = Str::isUrl($path) ? Str::of(asset($path)) : Str::of($path.$this->cachebusting);
+        $asset = Str::isUrl($path) ? Str::of(asset($path)) : Str::of(asset($path.$this->cachebusting));
 
         if ($this->useRelativePaths && $asset->startsWith(url(''))) {
             $asset = $asset->after('//')->after('/')->start('/');


### PR DESCRIPTION
reported in #148 

after removing the cache busting string from urls, an issue was introduced with relative paths. 

This fixes the reported issue and makes the relative paths work again. 