### PR TITLE
Add support to use a CDN along with basset

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,7 @@ Take a look at [the config file](https://github.com/Laravel-Backpack/basset/blob
 - enable/disable dev mode using `BASSET_DEV_MODE=false` - this will force Basset to internalize assets even on localhost
 - change the disk where assets get internalized using `BASSET_DISK=yourdiskname`
 - disable the cache map using `BASSET_CACHE_MAP=false` (needed on serverless like Laravel Vapor)
+- use an external CDN together with Basset using `BASSET_CDN_URL=https://yoursite.examplecdnprovider`
 
 ## Deployment
 

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -76,7 +76,7 @@ class FileOutput
             $asset = $asset->after('//')->after('/')->start('/');
         }
 
-        return $asset->value();
+        return config('backpack.basset.cdn_url') . $asset->value();
     }
 
     /**

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -25,4 +25,8 @@ return [
 
     // use relative path
     'relative_paths' => env('BASSET_RELATIVE_PATHS', true),
+
+    // Populate this to use a CDN like AWS Cloudfront with basset.  
+    // Example: https://example.cloudfront.net
+    'cdn_url' => env('BASSET_CDN_URL', ''), 
 ];


### PR DESCRIPTION
This is a simple change to configuration and code to simplify the use of an external CDN with basset.  I'm using this together with AWS Cloudfront.  We set the BASSET_CDN_URL to https://example.cloudfront.net.  That allows us to use basset to collect all external files into our site and minimize our server traffic requirements at the same time.