### PR TITLE
Fix CacheMap when cache is corrupted

### DIFF
--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -30,8 +30,13 @@ class CacheMap
         $this->basePath = $basePath;
         $this->filePath = $this->disk->path($this->basePath.'.basset');
 
-        if (File::exists($this->filePath)) {
-            $this->map = json_decode(File::get($this->filePath), true);
+        try {
+            if (File::exists($this->filePath)) {
+                $decoded = json_decode(File::get($this->filePath), true);
+                $this->map = is_array($decoded) ? $decoded : [];
+            }
+        } catch (\Throwable) {
+            $this->map = [];
         }
     }
 


### PR DESCRIPTION
Hi,

The goal of this PR is to prevent errors of this sort:
```
TypeError: Cannot assign null to property Backpack\Basset\Helpers\CacheMap::$map of type array

/vendor/backpack/basset/src/Helpers/CacheMap.php:31
/vendor/backpack/basset/src/BassetManager.php:45
/vendor/backpack/basset/src/BassetServiceProvider.php:72
/vendor/laravel/framework/src/Illuminate/Container/Container.php:952
/vendor/laravel/framework/src/Illuminate/Container/Container.php:832
/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1078
/vendor/laravel/framework/src/Illuminate/Container/Container.php:763
/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:1058
/vendor/laravel/framework/src/Illuminate/Container/Container.php:1580
/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:239
/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:210
/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:355
/vendor/backpack/crud/src/BackpackServiceProvider.php:65
[...]
```

I observed this error in very rare occasions so I'm not sure how to reproduce.