### PR TITLE
Allow extra attributes on scripts

### DIFF
--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -258,7 +258,7 @@ class BassetManager
             $this->markAsLoaded($asset);
 
             if ($output) {
-                echo $code;
+                echo $this->output->injectToBlock($code);
             }
 
             return $this->loader->finish(StatusEnum::LOADED);
@@ -276,7 +276,7 @@ class BassetManager
         // fallback to code on dev mode
         if ($this->dev) {
             if ($output) {
-                echo $code;
+                echo $this->output->injectToBlock($code);
             }
 
             return $this->loader->finish(StatusEnum::DISABLED);
@@ -330,7 +330,7 @@ class BassetManager
         }
         // Fallback to the code
         if ($output) {
-            echo $code;
+            echo $this->output->injectToBlock($code);
         }
 
         return $this->loader->finish(StatusEnum::INVALID);

--- a/src/BassetServiceProvider.php
+++ b/src/BassetServiceProvider.php
@@ -124,7 +124,7 @@ class BassetServiceProvider extends ServiceProvider
                 $cleanParameter = Str::of($parameter)->trim("'")->trim('"')->trim('`');
                 $filePath = Str::of($cleanParameter)->before('?')->before('#');
 
-                if (Str::endsWith($filePath, ['.js', '.css'])) {
+                if ($filePath->endsWith(['.js', '.css'])) {
                     return "<?php Basset::basset({$parameter}); ?>";
                 }
 

--- a/src/Helpers/FileOutput.php
+++ b/src/Helpers/FileOutput.php
@@ -16,11 +16,14 @@ class FileOutput
 
     private array $templates = [];
 
+    private array $scriptAttributes = [];
+
     public function __construct()
     {
         $this->nonce = config('backpack.basset.nonce', null);
         $this->cachebusting = '?'.substr(md5(base_path('composer.lock')), 0, 12);
         $this->useRelativePaths = config('backpack.basset.relative_paths', true);
+        $this->scriptAttributes = config('backpack.basset.script_attributes', []);
 
         // load all templates
         $templates = File::allFiles(realpath(__DIR__.'/../resources/views'));
@@ -86,8 +89,26 @@ class FileOutput
      * @param  array  $attributes
      * @return string
      */
+    /**
+     * Inject the configured script_attributes into every <script> tag found in a
+     * raw code block (used when Basset falls back to echoing inline code directly).
+     */
+    public function injectToBlock(string $code): string
+    {
+        if (empty($this->scriptAttributes)) {
+            return $code;
+        }
+
+        $attrs = $this->prepareAttributes();
+
+        return preg_replace('/<script\b/i', '<script'.$attrs, $code);
+    }
+
     private function prepareAttributes(array $attributes = []): string
     {
+        // Merge global script_attributes as defaults; per-asset attributes take precedence.
+        $attributes = array_merge($this->scriptAttributes, $attributes);
+
         if ($this->nonce) {
             $attributes['nonce'] ??= $this->nonce;
         }

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -48,4 +48,9 @@ return [
 
     // use relative path
     'relative_paths' => env('BASSET_RELATIVE_PATHS', true),
+
+    // Extra attributes to add to every <script> tag output by Basset.
+    // Useful for opt-out directives on CDN/proxy layers that rewrite scripts.
+    // Example (Cloudflare Rocket Loader): ['data-cfasync' => 'false']
+    'script_attributes' => [],
 ];

--- a/tests/Feature/DevModeTest.php
+++ b/tests/Feature/DevModeTest.php
@@ -29,7 +29,7 @@ it('ignores basset block on dev mode', function ($asset) {
 
     $codeBlock = getStub($asset);
 
-    $result = bassetInstance()->bassetBlock($asset, $codeBlock, false);
+    $result = bassetInstance()->bassetBlock($asset, $codeBlock);
 
     $path = bassetInstance()->buildCacheEntry($asset)->getPathOnDiskHashed($codeBlock);
 

--- a/tests/Feature/ScriptAttributesTest.php
+++ b/tests/Feature/ScriptAttributesTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use Backpack\Basset\Helpers\FileOutput;
+
+// ─── FileOutput::injectToBlock() unit tests ───────────────────────────────────
+
+it('injectToBlock returns code unchanged when script_attributes is empty', function () {
+    $output = new FileOutput();
+    $code = '<script>alert("hello")</script>';
+
+    expect($output->injectToBlock($code))->toBe($code);
+});
+
+it('injectToBlock injects a valued attribute into a script tag', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    $output = new FileOutput();
+
+    expect($output->injectToBlock('<script>fn()</script>'))
+        ->toBe('<script data-cfasync="false">fn()</script>');
+});
+
+it('injectToBlock injects a boolean attribute into a script tag', function () {
+    config(['backpack.basset.script_attributes' => ['defer' => true]]);
+    $output = new FileOutput();
+
+    expect($output->injectToBlock('<script>fn()</script>'))
+        ->toBe('<script defer>fn()</script>');
+});
+
+it('injectToBlock injects an empty-value attribute as a boolean attribute', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => '']]);
+    $output = new FileOutput();
+
+    expect($output->injectToBlock('<script>fn()</script>'))
+        ->toBe('<script data-cfasync>fn()</script>');
+});
+
+it('injectToBlock injects multiple attributes into a script tag', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false', 'defer' => true]]);
+    $output = new FileOutput();
+
+    expect($output->injectToBlock('<script>fn()</script>'))
+        ->toBe('<script data-cfasync="false" defer>fn()</script>');
+});
+
+it('injectToBlock injects into every script tag when multiple are present in the block', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    $output = new FileOutput();
+
+    $result = $output->injectToBlock('<script>fn1()</script><script>fn2()</script>');
+
+    expect($result)->toBe('<script data-cfasync="false">fn1()</script><script data-cfasync="false">fn2()</script>');
+});
+
+it('injectToBlock does not modify style tags', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    $output = new FileOutput();
+    $code = '<style>body { color: red; }</style>';
+
+    expect($output->injectToBlock($code))->toBe($code);
+});
+
+it('injectToBlock is case insensitive for the script tag name', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    $output = new FileOutput();
+
+    $result = $output->injectToBlock('<SCRIPT>fn()</SCRIPT>');
+
+    // preg_replace uses a literal replacement, so the matched tag is normalised to lowercase
+    expect($result)->toContain('<script data-cfasync="false">');
+});
+
+it('injectToBlock preserves existing attributes on the script tag', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    $output = new FileOutput();
+
+    $result = $output->injectToBlock('<script async type="module">fn()</script>');
+
+    expect($result)->toBe('<script data-cfasync="false" async type="module">fn()</script>');
+});
+
+// ─── write() integration tests ────────────────────────────────────────────────
+
+it('adds script_attributes to the script src tag for cdn assets', function ($asset) {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    ob_start();
+    bassetInstance($asset);
+    $html = ob_get_clean();
+
+    expect($html)->toContain('data-cfasync="false"');
+})->with('cdn');
+
+it('per-asset attributes override matching global script_attributes', function ($asset) {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    ob_start();
+    bassetInstance($asset, true, ['data-cfasync' => 'true']);
+    $html = ob_get_clean();
+
+    expect($html)
+        ->toContain('data-cfasync="true"')
+        ->not->toContain('data-cfasync="false"');
+})->with('cdn');
+
+it('per-asset attributes are merged with global script_attributes when keys differ', function ($asset) {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    ob_start();
+    bassetInstance($asset, true, ['crossorigin' => 'anonymous']);
+    $html = ob_get_clean();
+
+    expect($html)
+        ->toContain('data-cfasync="false"')
+        ->toContain('crossorigin="anonymous"');
+})->with('cdn');
+
+it('nonce and script_attributes both appear on the script src tag', function ($asset) {
+    config([
+        'backpack.basset.script_attributes' => ['data-cfasync' => 'false'],
+        'backpack.basset.nonce' => 'test-nonce-123',
+    ]);
+
+    ob_start();
+    bassetInstance($asset);
+    $html = ob_get_clean();
+
+    expect($html)
+        ->toContain('data-cfasync="false"')
+        ->toContain('nonce="test-nonce-123"');
+})->with('cdn');
+
+// ─── bassetBlock() echo paths ─────────────────────────────────────────────────
+
+it('injects script_attributes when echoing a block in dev mode', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    bassetInstance()->setDevMode(true);
+
+    ob_start();
+    bassetInstance()->bassetBlock('test-asset.js', '<script>fn()</script>');
+    $html = ob_get_clean();
+
+    expect($html)->toContain('data-cfasync="false"');
+});
+
+it('injects script_attributes when echoing a block with cache disabled', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    ob_start();
+    bassetInstance()->bassetBlock('test-asset.js', '<script>fn()</script>', true, false);
+    $html = ob_get_clean();
+
+    expect($html)->toContain('data-cfasync="false"');
+});
+
+it('does not inject script_attributes into style blocks in dev mode', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+    bassetInstance()->setDevMode(true);
+
+    $cssCode = '<style>body { color: red; }</style>';
+
+    ob_start();
+    bassetInstance()->bassetBlock('test-asset.css', $cssCode);
+    $html = ob_get_clean();
+
+    expect($html)
+        ->toBe($cssCode)
+        ->not->toContain('data-cfasync');
+});

--- a/tests/Feature/ScriptAttributesTest.php
+++ b/tests/Feature/ScriptAttributesTest.php
@@ -2,8 +2,6 @@
 
 use Backpack\Basset\Helpers\FileOutput;
 
-// ─── FileOutput::injectToBlock() unit tests ───────────────────────────────────
-
 it('injectToBlock returns code unchanged when script_attributes is empty', function () {
     $output = new FileOutput();
     $code = '<script>alert("hello")</script>';
@@ -166,4 +164,40 @@ it('does not inject script_attributes into style blocks in dev mode', function (
     expect($html)
         ->toBe($cssCode)
         ->not->toContain('data-cfasync');
+});
+
+// ─── bassetBlock() cached (write) paths ───────────────────────────────────────
+
+it('adds script_attributes to the script src tag when a basset block is internalized', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    ob_start();
+    bassetInstance()->bassetBlock('test-block.js', '<script>fn()</script>');
+    $html = ob_get_clean();
+
+    // The block should be internalized and output as a <script src> tag
+    expect($html)
+        ->toContain('<script')
+        ->toContain('data-cfasync="false"');
+});
+
+it('adds script_attributes to the script src tag when a basset block is served from cache', function () {
+    config(['backpack.basset.script_attributes' => ['data-cfasync' => 'false']]);
+
+    $code = '<script>fn()</script>';
+
+    // First request — internalizes and caches
+    bassetInstance()->bassetBlock('test-block.js', $code);
+
+    // Reset loaded so the second request is not skipped as already-loaded
+    bassetInstance()->clearLoadedAssets();
+
+    ob_start();
+    // Second request — served from cache map / disk
+    bassetInstance()->bassetBlock('test-block.js', $code);
+    $html = ob_get_clean();
+
+    expect($html)
+        ->toContain('<script')
+        ->toContain('data-cfasync="false"');
 });


### PR DESCRIPTION
This adds an important missing funcionatily in basset, specially in the script tags, the ability to add custom tags to backpack "core" scripts, without having to overwritte the core backpack files. 

Two examples of such use cases are: 
https://github.com/Laravel-Backpack/basset/issues/172 and https://github.com/Laravel-Backpack/community-forum/issues/1450

Tests were also added to confirm the working solution.