### PR TITLE
Improve asset caching mechanism

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,12 +193,15 @@ Copying an asset from CDNs to your server could take a bit of time, depending on
 
 ```bash 
 php artisan basset:cache         # internalizes all @bassets and named assets
+php artisan basset:cache --stale # same as above, also removes assets no longer referenced
 php artisan basset:clear         # clears the basset directory
 php artisan basset:fresh         # runs clear + cache back-to-back
 php artisan basset:list-named    # shows all registered named assets
 ```
 
-In order to speed up the first page load on production, we recommend you to add `php artisan basset:cache` command to your deploy script.
+In order to speed up the first page load on production, we recommend you to add `php artisan basset:cache` command to your deploy script. If you want to also remove assets that are no longer referenced in your blade files, use `php artisan basset:cache --stale`.
+
+> **Note:** In previous versions we recommended `basset:fresh` (clear + cache). That is no longer necessary — `basset:cache` alone is sufficient. It preserves already-cached assets, skipping re-downloads for URLs that haven't changed, which makes your deployments faster and safer against CDN outages.
 
 ## Configuration
 
@@ -206,6 +209,8 @@ Take a look at [the config file](https://github.com/Laravel-Backpack/basset/blob
 - enable/disable dev mode using `BASSET_DEV_MODE=false` - when enabled Basset will check for changes in your url/files and update the cached assets
 - change the disk where assets get internalized using `BASSET_DISK=yourdiskname`
 - disable the cache map using `BASSET_CACHE_MAP=false` (needed on serverless like Laravel Vapor)
+- configure HTTP fetch behavior with `BASSET_FETCH_TIMEOUT` (default 30s), `BASSET_FETCH_RETRIES` (default 3 attempts), and `BASSET_FETCH_RETRY_DELAY` (default 10000ms between retries)
+- enable URL comparison to skip re-downloads with `BASSET_CACHE_MAP_COMPARISON=true` — when enabled, `basset:cache` will skip re-downloading assets whose URL hasn't changed since the last cache (safe for versioned CDN URLs)
 
 ### Dev Mode
 
@@ -218,7 +223,7 @@ There are a lot of deployment options for Laravel apps, but we'll try to cover t
 ### VPS / SSH / Composer available
 
 - it is mandatory to run `php artisan storage:link` in production, for Basset to work; so it's recommended you add that to your `composer.json`'s scripts section, either under `post-composer-install` or `post-composer-update`;
-- it is recommended to run `php artisan basset:fresh` after each deployment; so it's recommended you add that to your `composer.json`'s scripts section, either under `post-composer-update`;
+- it is recommended to run `php artisan basset:cache` after each deployment; optionally add `--stale` to clean up assets no longer referenced; so it's recommended you add that to your `composer.json`'s scripts section, either under `post-composer-update`;
 
 ### Laravel Forge
 
@@ -240,7 +245,7 @@ BASSET_CACHE_MAP=false
 
 If you deploy your project by uploading it from localhost (either manually or automatically), you should:
 - make sure the alias exists that would have been created by `php artisan storage:link`; otherwise your alias might point to an inexisting localhost path; alternatively you can change the disk that Basset is using, in its config;
-- before each deployment, make sure to disable dev mode (`do BASSET_DEV_MODE=false` in your `.ENV` file) then run `php artisan basset:fresh`; that will make sure your localhost downloads all assets, then you upload them in your zip;
+- before each deployment, make sure to disable dev mode (`do BASSET_DEV_MODE=false` in your `.ENV` file) then run `php artisan basset:cache`; that will make sure your localhost downloads all assets, then you upload them in your zip;
 
 
 ## Why does this package exist?
@@ -313,6 +318,7 @@ Basset provides a few options out-of-the-box:
 - **`basset` disk** - inside the storage directory (eg. `storage/app/basset`) [DEFAULT]
     - PROs: the Git history is clean - because your cached assets will NOT be tracked by Git;
     - CONs: you have to run `php artisan basset:cache` in your deploy script, which adds seconds to your deploy time; plus, it opens up a corner case on deployment - because assets are being re-cached upon deployment, if a CDN is down during deployment, the system will not be able to internalize it; if will however internalize it when the CDN is back on, and the page that loads the file gets accessed; we consider the tradeoffs minor and unlikely, which is why this is the DEFAULT;
+    - The `.basset` cache map file is stored privately at `storage/app/basset/.basset` (not publicly accessible).
     - How to enable: do nothing, or do `BASSET_DISK=basset` in your .env file;
 - **`public_basset` disk** - inside the public directory (eg. `public/basset`)
     - PROs: you are certain the same assets you have on localhost will be in production, because the assets are commited to Git;

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -113,6 +113,20 @@ class BassetManager
     }
 
     /**
+     * Checks if the asset is already cached (exists on disk AND in the cache map).
+     * Used by basset:cache to skip re-downloading assets that haven't changed.
+     *
+     * @return bool
+     */
+    public function isAssetCached(CacheEntry|string $asset): bool
+    {
+        $entry = $this->buildCacheEntry($asset);
+        $mapped = $this->cacheMap->getAsset($entry);
+
+        return $mapped !== false && $entry->existsOnDisk($this->disk);
+    }
+
+    /**
      * Returns the current loaded basset list on app lifecycle.
      *
      * @return array
@@ -177,23 +191,30 @@ class BassetManager
         if ($mapped) {
             // if dev mode is not active we will just return the cached asset
             if (! $this->dev) {
-                $output && $this->output->write($mapped);
+                // Only trust the cache map if the file actually exists on disk
+                if ($asset->existsOnDisk($this->disk)) {
+                    $output && $this->output->write($mapped);
 
-                return $this->loader->finish(StatusEnum::IN_CACHE);
-            }
-
-            if (Str::isUrl($mapped->getAssetPath())) {
-                if ($mapped->getAssetPath() !== $asset->getAssetPath()) {
-                    return $this->replaceAsset($asset, $mapped, $output);
+                    return $this->loader->finish(StatusEnum::IN_CACHE);
                 }
 
-                $output && $this->output->write($mapped);
+                // Cache map entry exists but file is missing — remove stale entry and re-download
+                $this->cacheMap->delete($mapped);
+            } else {
+                // Dev mode: compare URL or content hash to detect changes
+                if (Str::isUrl($mapped->getAssetPath())) {
+                    if ($mapped->getAssetPath() !== $asset->getAssetPath()) {
+                        return $this->replaceAsset($asset, $mapped, $output);
+                    }
 
-                return $this->loader->finish(StatusEnum::IN_CACHE);
-            }
+                    $output && $this->output->write($mapped);
 
-            if ($mapped->getContentHash() !== $asset->generateContentHash()) {
-                return $this->replaceAsset($asset, $mapped, $output);
+                    return $this->loader->finish(StatusEnum::IN_CACHE);
+                }
+
+                if ($mapped->getContentHash() !== $asset->generateContentHash()) {
+                    return $this->replaceAsset($asset, $mapped, $output);
+                }
             }
         }
 
@@ -476,12 +497,24 @@ class BassetManager
 
     /**
      * Fetch the content body of an url.
+     *
+     * @throws \RuntimeException when all retry attempts fail or the final response is non-2xx
      */
     public function fetchContent(string $url): string
     {
-        return Http::withOptions(['verify' => config('backpack.basset.verify_ssl_certificate', true)])
-            ->get($url)
-            ->body();
+        $retries = (int) config('backpack.basset.fetch_retries', 3);
+        $retryDelay = (int) config('backpack.basset.fetch_retry_delay', 10000);
+
+        $response = Http::withOptions(['verify' => config('backpack.basset.verify_ssl_certificate', true)])
+            ->timeout(config('backpack.basset.fetch_timeout', 30))
+            ->retry($retries, $retryDelay)
+            ->get($url);
+
+        if (! $response->successful()) {
+            throw new \RuntimeException("Failed to fetch asset from '$url': HTTP {$response->status()} after {$retries} retries");
+        }
+
+        return $response->body();
     }
 
     private function replaceAsset(CacheEntry $asset, CacheEntry $mapped, $output): StatusEnum
@@ -502,7 +535,13 @@ class BassetManager
     private function getAssetContent(CacheEntry $asset, bool $output = true): StatusEnum|string
     {
         if (Str::isUrl($asset->getAssetPath())) {
-            $content = $this->fetchContent($asset->getAssetPath());
+            try {
+                $content = $this->fetchContent($asset->getAssetPath());
+            } catch (\Throwable $e) {
+                report($e);
+
+                return $this->loader->finish(StatusEnum::INVALID);
+            }
         } else {
             if (! $asset->isLocalAsset()) {
                 return $this->loader->finish(StatusEnum::INVALID);

--- a/src/Console/Commands/BassetCache.php
+++ b/src/Console/Commands/BassetCache.php
@@ -23,7 +23,8 @@ class BassetCache extends Command
      *
      * @var string
      */
-    protected $signature = 'basset:cache';
+    protected $signature = 'basset:cache
+                            {--stale : Remove cached assets that are no longer referenced in blade files}';
 
     /**
      * The console command description.
@@ -112,6 +113,29 @@ class BassetCache extends Command
                 $args[2] = false;
             }
 
+            // Skip if the asset is a URL already cached (URL identity = content identity).
+            // Local files are never skipped — re-copying is cheap and content may have changed.
+            // Only active when cache_map_comparison is enabled (opt-in).
+            if (config('backpack.basset.cache_map_comparison') && $this->shouldSkipCachedAsset($args[0])) {
+                $internalizedAssets[] = $args[0];
+
+                if ($this->getOutput()->isVerbose()) {
+                    $this->line(str_pad(strval($i + 1), 3, ' ', STR_PAD_LEFT).' '.$args[0]);
+                    $this->line('    '.StatusEnum::SKIPPED->value);
+                    $this->newLine();
+                } else {
+                    $bar->advance();
+                }
+
+                return;
+            }
+
+            // When cache_map_comparison is enabled and this is a local file that's
+            // already cached, delete the old copy to force a fresh re-copy.
+            if (config('backpack.basset.cache_map_comparison') && $type === 'basset') {
+                $this->invalidateCachedLocalFile($args[0]);
+            }
+
             try {
                 if (in_array($type, ['basset', 'bassetArchive', 'bassetDirectory', 'bassetBlock'])) {
                     $result = Basset::{$type}(...$args)->value;
@@ -157,6 +181,14 @@ class BassetCache extends Command
 
         $notInternalizedAssets = implode(', ', array_unique($notInternalizedAssets));
 
+        // Remove stale assets that are no longer referenced in blade files
+        if ($this->option('stale')) {
+            $staleCount = $this->cleanStaleAssets($internalizedAssets);
+            if ($staleCount > 0) {
+                $this->line("Removed $staleCount stale asset(s).");
+            }
+        }
+
         // Save the cache map
         Basset::cacheMap()->save();
 
@@ -169,6 +201,77 @@ class BassetCache extends Command
 
         $this->newLine(2);
         $this->info(sprintf('Done in %.2fs', microtime(true) - $starttime));
+    }
+
+    /**
+     * Delete a cached local file from disk so it will be re-copied.
+     * URL assets are left alone — they are handled by shouldSkipCachedAsset.
+     *
+     * @param  string  $asset
+     * @return void
+     */
+    private function invalidateCachedLocalFile(string $asset): void
+    {
+        $entry = Basset::buildCacheEntry($asset);
+
+        // Only invalidate local (non-URL) assets
+        if (Str::isUrl($entry->getAssetPath())) {
+            return;
+        }
+
+        $disk = \Illuminate\Support\Facades\Storage::disk(config('backpack.basset.disk'));
+        if ($entry->existsOnDisk($disk)) {
+            $disk->delete($entry->getAssetDiskPath());
+        }
+    }
+
+    /**
+     * Determine if an asset should be skipped (already cached and is a URL).
+     * Local files are never skipped — re-copying is cheap and content may have changed.
+     *
+     * @param  string  $asset
+     * @return bool
+     */
+    private function shouldSkipCachedAsset(string $asset): bool
+    {
+        $entry = Basset::buildCacheEntry($asset);
+
+        // Only skip URL assets — they're identified by their URL string
+        if (! Str::isUrl($entry->getAssetPath())) {
+            return false;
+        }
+
+        return Basset::isAssetCached($asset);
+    }
+
+    /**
+     * Remove cached assets that are no longer referenced in blade files.
+     *
+     * @param  array  $activeAssets  Asset names found in current blade files
+     * @return int  Number of stale assets removed
+     */
+    private function cleanStaleAssets(array $activeAssets): int
+    {
+        $cacheMap = Basset::cacheMap();
+        $allCachedAssets = array_keys($cacheMap->getMap());
+        $staleAssets = array_diff($allCachedAssets, $activeAssets);
+
+        $count = 0;
+        foreach ($staleAssets as $staleAsset) {
+            $entry = Basset::buildCacheEntry($staleAsset);
+
+            // Delete the file from disk
+            $disk = $cacheMap->getDisk();
+            if ($disk && $disk->exists($entry->getAssetDiskPath())) {
+                $disk->delete($entry->getAssetDiskPath());
+            }
+
+            // Remove from cache map
+            $cacheMap->delete($entry);
+            $count++;
+        }
+
+        return $count;
     }
 
     /**

--- a/src/Console/Commands/BassetCache.php
+++ b/src/Console/Commands/BassetCache.php
@@ -116,7 +116,7 @@ class BassetCache extends Command
             // Skip if the asset is a URL already cached (URL identity = content identity).
             // Local files are never skipped — re-copying is cheap and content may have changed.
             // Only active when cache_map_comparison is enabled (opt-in).
-            if (config('backpack.basset.cache_map_comparison') && $this->shouldSkipCachedAsset($args[0])) {
+            if (config('backpack.basset.cache_map_comparison') && $this->shouldSkipCachedAsset($args[0], $args[2] ?? [])) {
                 $internalizedAssets[] = $args[0];
 
                 if ($this->getOutput()->isVerbose()) {
@@ -130,10 +130,11 @@ class BassetCache extends Command
                 return;
             }
 
-            // When cache_map_comparison is enabled and this is a local file that's
-            // already cached, delete the old copy to force a fresh re-copy.
-            if (config('backpack.basset.cache_map_comparison') && $type === 'basset') {
-                $this->invalidateCachedLocalFile($args[0]);
+            // When the asset already exists on disk, delete the old copy to force
+            // a fresh download/copy. Applies to: local files (when comparison enabled)
+            // and URL assets with the 'refresh' attribute.
+            if ($type === 'basset') {
+                $this->invalidateCachedLocalFile($args[0], $args[2] ?? []);
             }
 
             try {
@@ -171,6 +172,20 @@ class BassetCache extends Command
             });
 
         foreach ($namedAssets as $id => $asset) {
+            // Skip if the named asset is already cached (when comparison enabled and no refresh flag)
+            $namedAttributes = $asset['attributes'] ?? [];
+            if (config('backpack.basset.cache_map_comparison')
+                && ! ($namedAttributes['refresh'] ?? false)
+                && Basset::isAssetCached($id)) {
+                $internalizedAssets[] = $id;
+                continue;
+            }
+
+            // If refresh is set, invalidate the old cached file to force re-download
+            if ($namedAttributes['refresh'] ?? false) {
+                $this->invalidateCachedLocalFile($id);
+            }
+
             $result = Basset::basset($id, false)->value;
             if ($result !== StatusEnum::INVALID->value) {
                 $internalizedAssets[] = $id;
@@ -204,18 +219,23 @@ class BassetCache extends Command
     }
 
     /**
-     * Delete a cached local file from disk so it will be re-copied.
-     * URL assets are left alone — they are handled by shouldSkipCachedAsset.
+     * Remove a cached file from disk if present, forcing a fresh download/copy.
+     * Invalidates when: the 'refresh' attribute is set, OR it's a local file
+     * and cache_map_comparison is enabled.
      *
      * @param  string  $asset
      * @return void
      */
-    private function invalidateCachedLocalFile(string $asset): void
+    private function invalidateCachedLocalFile(string $asset, array $attributes = []): void
     {
         $entry = Basset::buildCacheEntry($asset);
+        $attributes = array_merge($entry->getAttributes(), $attributes);
+        $isUrl = Str::isUrl($entry->getAssetPath());
 
-        // Only invalidate local (non-URL) assets
-        if (Str::isUrl($entry->getAssetPath())) {
+        $shouldInvalidate = ($attributes['refresh'] ?? false)
+            || (! $isUrl && config('backpack.basset.cache_map_comparison'));
+
+        if (! $shouldInvalidate) {
             return;
         }
 
@@ -232,9 +252,14 @@ class BassetCache extends Command
      * @param  string  $asset
      * @return bool
      */
-    private function shouldSkipCachedAsset(string $asset): bool
+    private function shouldSkipCachedAsset(string $asset, array $attributes = []): bool
     {
         $entry = Basset::buildCacheEntry($asset);
+
+        // Never skip if the asset has the 'refresh' attribute
+        if (($attributes['refresh'] ?? false) || ($entry->getAttributes()['refresh'] ?? false)) {
+            return false;
+        }
 
         // Only skip URL assets — they're identified by their URL string
         if (! Str::isUrl($entry->getAssetPath())) {

--- a/src/Console/Commands/BassetCache.php
+++ b/src/Console/Commands/BassetCache.php
@@ -248,7 +248,7 @@ class BassetCache extends Command
      * Remove cached assets that are no longer referenced in blade files.
      *
      * @param  array  $activeAssets  Asset names found in current blade files
-     * @return int  Number of stale assets removed
+     * @return int Number of stale assets removed
      */
     private function cleanStaleAssets(array $activeAssets): int
     {

--- a/src/Console/Commands/BassetClear.php
+++ b/src/Console/Commands/BassetClear.php
@@ -4,6 +4,7 @@ namespace Backpack\Basset\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -44,7 +45,12 @@ class BassetClear extends Command
 
         $disk->deleteDirectory($path);
         $disk->makeDirectory($path);
+
+        // Remove cache map from both old (public) and new (private) locations
         $disk->delete('.basset');
+        if (File::exists(storage_path('basset/.basset'))) {
+            File::delete(storage_path('basset/.basset'));
+        }
 
         $this->info('Done');
     }

--- a/src/Enums/StatusEnum.php
+++ b/src/Enums/StatusEnum.php
@@ -10,4 +10,6 @@ enum StatusEnum: string
     case INVALID = 'Not in a CDN or local filesystem, falling back to provided path';
     case PUBLIC_FILE = 'Public file, no need to internalize';
     case DISABLED = 'Development mode active';
+    case SKIPPED = 'Skipped (already cached, URL unchanged)';
+    case DOWNLOAD_FAILED = 'Download failed, could not fetch asset';
 }

--- a/src/Helpers/CacheMap.php
+++ b/src/Helpers/CacheMap.php
@@ -28,7 +28,16 @@ class CacheMap
 
         $this->disk = $disk;
         $this->basePath = $basePath;
-        $this->filePath = $this->disk->path($this->basePath.'.basset');
+        $this->filePath = storage_path('basset/.basset');
+
+        // Migration: if no file at new private location, try old public location
+        if (! File::exists($this->filePath)) {
+            $oldPath = $this->disk->path($this->basePath.'.basset');
+            if (File::exists($oldPath)) {
+                File::ensureDirectoryExists(dirname($this->filePath), 0755, true);
+                File::copy($oldPath, $this->filePath);
+            }
+        }
 
         try {
             if (File::exists($this->filePath)) {
@@ -49,6 +58,12 @@ class CacheMap
     {
         if (! $this->isDirty || ! $this->isActive) {
             return;
+        }
+
+        // ensure the directory exists before writing
+        $dir = dirname($this->filePath);
+        if (! File::isDirectory($dir)) {
+            File::makeDirectory($dir, 0755, true);
         }
 
         // save file
@@ -97,5 +112,15 @@ class CacheMap
     public function getMap(): array
     {
         return $this->map;
+    }
+
+    /**
+     * Get the disk used by the cache map.
+     *
+     * @return \Illuminate\Filesystem\FilesystemAdapter|null
+     */
+    public function getDisk(): ?FilesystemAdapter
+    {
+        return $this->isActive ? $this->disk : null;
     }
 }

--- a/src/config/backpack/basset.php
+++ b/src/config/backpack/basset.php
@@ -8,6 +8,15 @@ return [
     // verify ssl certificate while fetching assets
     'verify_ssl_certificate' => env('BASSET_VERIFY_SSL_CERTIFICATE', true),
 
+    // maximum time (in seconds) to wait for a response when fetching an asset
+    'fetch_timeout' => env('BASSET_FETCH_TIMEOUT', 30),
+
+    // total number of HTTP attempts (initial + retries) when fetching an asset
+    'fetch_retries' => env('BASSET_FETCH_RETRIES', 3),
+
+    // delay (in milliseconds) between each retry attempt
+    'fetch_retry_delay' => env('BASSET_FETCH_RETRY_DELAY', 10000),
+
     // disk and path where to store bassets
     'disk' => env('BASSET_DISK', 'basset'),
 
@@ -17,6 +26,11 @@ return [
 
     // use cache map file (.basset).
     'cache_map' => env('BASSET_CACHE_MAP', true),
+
+    // when enabled, basset:cache will skip re-downloading assets that are
+    // already cached (same URL in cache map + file exists on disk).
+    // set to true once you've verified your CDN URLs are properly versioned.
+    'cache_map_comparison' => env('BASSET_CACHE_MAP_COMPARISON', false),
 
     // view paths that may use @basset
     // used to internalize assets in advance with artisan basset:internalize

--- a/tests/Feature/CacheCommandTest.php
+++ b/tests/Feature/CacheCommandTest.php
@@ -1,0 +1,304 @@
+<?php
+
+use Backpack\Basset\Enums\StatusEnum;
+use Backpack\Basset\Facades\Basset;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->tempDir = storage_path('framework/testing/disks/basset-test');
+    File::ensureDirectoryExists($this->tempDir);
+    Basset::addViewPath($this->tempDir);
+
+    // ensure cache map and comparison are enabled for these tests
+    config(['backpack.basset.cache_map' => true]);
+    config(['backpack.basset.cache_map_comparison' => true]);
+    config(['backpack.basset.dev_mode' => false]);
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->tempDir);
+});
+
+it('skips re-downloading assets already in cache map and on disk', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // pre-populate: put the file on disk and add to cache map
+    disk()->put($diskPath, getStub('vue.global.prod.js'));
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+
+    // create a blade file referencing the asset
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // the file should still be there, and no HTTP request should have been made
+    disk()->assertExists($diskPath);
+    // the cache map should still have the entry
+    expect(Basset::cacheMap()->getMap())->toHaveKey($assetUrl);
+});
+
+it('downloads assets not in cache map', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // no pre-populated cache — asset needs downloading
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    disk()->assertExists($diskPath);
+    expect(Basset::cacheMap()->getMap())->toHaveKey($assetUrl);
+});
+
+it('downloads assets when cache map has entry but file is missing from disk', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // add to cache map but do NOT put file on disk
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // should download because file was missing
+    disk()->assertExists($diskPath);
+});
+
+it('removes stale assets with --stale flag', function () {
+    $activeUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $staleUrl = 'https://unpkg.com/react@18/umd/react.production.min.js';
+
+    $activePath = bassetInstance()->assetPathsManager->getPathOnDisk($activeUrl);
+    $stalePath = bassetInstance()->assetPathsManager->getPathOnDisk($staleUrl);
+
+    // pre-populate both assets
+    disk()->put($activePath, getStub('vue.global.prod.js'));
+    disk()->put($stalePath, getStub('react.production.min.js'));
+
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($activeUrl));
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($staleUrl));
+    Basset::cacheMap()->save();
+
+    // only reference the active asset in the blade file
+    File::put($this->tempDir.'/test.blade.php', "@basset('$activeUrl', false)");
+
+    $this->artisan('basset:cache --stale');
+
+    // active asset should still exist
+    disk()->assertExists($activePath);
+    expect(Basset::cacheMap()->getMap())->toHaveKey($activeUrl);
+
+    // stale asset should be removed from disk and map
+    disk()->assertMissing($stalePath);
+    expect(Basset::cacheMap()->getMap())->not()->toHaveKey($staleUrl);
+});
+
+it('does not remove stale assets without --stale flag', function () {
+    $activeUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $staleUrl = 'https://unpkg.com/react@18/umd/react.production.min.js';
+
+    $activePath = bassetInstance()->assetPathsManager->getPathOnDisk($activeUrl);
+    $stalePath = bassetInstance()->assetPathsManager->getPathOnDisk($staleUrl);
+
+    // pre-populate both assets
+    disk()->put($activePath, getStub('vue.global.prod.js'));
+    disk()->put($stalePath, getStub('react.production.min.js'));
+
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($activeUrl));
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($staleUrl));
+    Basset::cacheMap()->save();
+
+    // only reference the active asset
+    File::put($this->tempDir.'/test.blade.php', "@basset('$activeUrl', false)");
+
+    // run WITHOUT --stale
+    $this->artisan('basset:cache');
+
+    // both should still exist
+    disk()->assertExists($activePath);
+    disk()->assertExists($stalePath);
+    expect(Basset::cacheMap()->getMap())->toHaveKey($activeUrl);
+    expect(Basset::cacheMap()->getMap())->toHaveKey($staleUrl);
+});
+
+it('isAssetCached returns true when asset is in map and on disk', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    disk()->put($diskPath, getStub('vue.global.prod.js'));
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($assetUrl));
+
+    expect(Basset::isAssetCached($assetUrl))->toBeTrue();
+});
+
+it('isAssetCached returns false when asset is not in map', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    disk()->put($diskPath, getStub('vue.global.prod.js'));
+    // not adding to cache map
+
+    expect(Basset::isAssetCached($assetUrl))->toBeFalse();
+});
+
+it('isAssetCached returns false when asset is in map but not on disk', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+
+    Basset::cacheMap()->addAsset(bassetInstance()->buildCacheEntry($assetUrl));
+    // not putting file on disk
+
+    expect(Basset::isAssetCached($assetUrl))->toBeFalse();
+});
+
+it('stores cache map in private storage path, not public disk', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // The .basset file should be at the private storage path
+    $privatePath = storage_path('basset/.basset');
+    expect(File::exists($privatePath))->toBeTrue();
+
+    // It should NOT be on the public disk
+    disk()->assertMissing('.basset');
+});
+
+it('migrates cache map from old public location to new private location', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Simulate an old install: .basset exists only on the public disk
+    $oldMap = [$assetUrl => [
+        'asset_name' => $assetUrl,
+        'asset_path' => $assetUrl,
+        'asset_disk_path' => $diskPath,
+        'asset_attributes' => [],
+        'asset_content_hash' => '',
+    ]];
+
+    $oldPath = disk()->path('basset/.basset');
+    File::ensureDirectoryExists(dirname($oldPath), 0755, true);
+    File::put($oldPath, json_encode($oldMap));
+
+    // Also put the file on disk so it looks cached
+    disk()->put($diskPath, getStub('vue.global.prod.js'));
+
+    // Private path should NOT exist yet
+    $privatePath = storage_path('basset/.basset');
+    if (File::exists($privatePath)) {
+        File::delete($privatePath);
+    }
+    expect(File::exists($privatePath))->toBeFalse();
+
+    // Run basset:cache — should trigger migration
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+    $this->artisan('basset:cache');
+
+    // Now the private path should exist with the migrated data
+    expect(File::exists($privatePath))->toBeTrue();
+    $migrated = json_decode(File::get($privatePath), true);
+    expect($migrated)->toHaveKey($assetUrl);
+});
+
+it('basset:clear removes cache map from both old and new locations', function () {
+    $privatePath = storage_path('basset/.basset');
+    $oldPath = disk()->path('basset/.basset');
+
+    // Put .basset in both locations
+    File::ensureDirectoryExists(dirname($privatePath), 0755, true);
+    File::put($privatePath, json_encode(['test' => 'data']));
+    File::ensureDirectoryExists(dirname($oldPath), 0755, true);
+    File::put($oldPath, json_encode(['test' => 'data']));
+
+    // Also put something on the public disk so clear doesn't fail
+    disk()->put('basset/sample.js', 'sample');
+
+    $this->artisan('basset:clear');
+
+    // Both should be gone
+    expect(File::exists($privatePath))->toBeFalse();
+    expect(File::exists($oldPath))->toBeFalse();
+});
+
+it('re-downloads cached assets when cache_map_comparison is disabled', function () {
+    config(['backpack.basset.cache_map_comparison' => false]);
+
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // pre-populate cache: file on disk + cache map entry
+    disk()->put($diskPath, getStub('vue.global.prod.js'));
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // Should still exist (re-downloaded or kept), but the point is
+    // it was NOT skipped — the old behavior is preserved
+    disk()->assertExists($diskPath);
+});
+
+it('does not skip local files even with cache_map_comparison enabled', function () {
+    // Use a path relative to base_path, which buildCacheEntry resolves automatically
+    $localFile = 'resources/js/test-local.js';
+    $absolutePath = base_path($localFile);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($absolutePath);
+
+    // Write the actual local file with NEW content
+    File::ensureDirectoryExists(dirname($absolutePath), 0755, true);
+    File::put($absolutePath, 'new content');
+
+    // Pre-populate basset cache with OLD content
+    disk()->put($diskPath, 'old content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($absolutePath)
+    );
+    Basset::cacheMap()->save();
+
+    // Use the simple relative path string in the blade (no base_path() call needed)
+    File::put($this->tempDir.'/test.blade.php', "@basset('$localFile', false)");
+
+    $this->artisan('basset:cache');
+
+    // Should have re-copied the file with the new content, not kept the old
+    expect(disk()->get($diskPath))->toBe('new content');
+
+    // Cleanup
+    File::delete($absolutePath);
+});
+
+it('re-copies local file even when content has not changed', function () {
+    $localFile = 'resources/js/test-unchanged.js';
+    $absolutePath = base_path($localFile);
+
+    // Write the local file
+    File::ensureDirectoryExists(dirname($absolutePath), 0755, true);
+    File::put($absolutePath, 'same content');
+
+    // Pre-populate cache with same content
+    $entry = bassetInstance()->buildCacheEntry($absolutePath);
+    disk()->put($entry->getAssetDiskPath(), 'same content');
+    Basset::cacheMap()->addAsset($entry);
+    Basset::cacheMap()->save();
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('$localFile', false)");
+
+    $this->artisan('basset:cache');
+
+    // Still exists (re-copied)
+    disk()->assertExists($entry->getAssetDiskPath());
+    expect(disk()->get($entry->getAssetDiskPath()))->toBe('same content');
+
+    // Cleanup
+    File::delete($absolutePath);
+});

--- a/tests/Feature/CacheCommandTest.php
+++ b/tests/Feature/CacheCommandTest.php
@@ -301,3 +301,117 @@ it('re-copies local file even when content has not changed', function () {
     // Cleanup
     File::delete($absolutePath);
 });
+
+it('always re-downloads URL asset when refresh attribute is set', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Pre-populate cache with old content
+    disk()->put($diskPath, 'stale content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+    Basset::cacheMap()->save();
+
+    File::put($this->tempDir.'/test.blade.php',
+        "@basset('$assetUrl', false, ['refresh' => true])"
+    );
+
+    $this->artisan('basset:cache');
+
+    // Should have re-downloaded fresh content, not kept stale
+    $expectedContent = getStub('vue.global.prod.js');
+    expect(disk()->get($diskPath))->toBe($expectedContent);
+});
+
+it('always re-downloads named asset when refresh attribute is set', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Map as named asset with refresh
+    Basset::map('refreshable-asset', $assetUrl, ['refresh' => true]);
+
+    // Pre-populate cache with old content
+    disk()->put($diskPath, 'stale content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+    Basset::cacheMap()->save();
+
+    // Reference the named asset in a blade file
+    File::put($this->tempDir.'/test.blade.php', "@basset('refreshable-asset', false)");
+
+    $this->artisan('basset:cache');
+
+    // Should have re-downloaded fresh content
+    $expectedContent = getStub('vue.global.prod.js');
+    expect(disk()->get($diskPath))->toBe($expectedContent);
+});
+
+it('does not skip URL asset when cache_map_comparison is disabled even without refresh', function () {
+    config(['backpack.basset.cache_map_comparison' => false]);
+
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Pre-populate cache with stale content
+    disk()->put($diskPath, 'stale content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+    Basset::cacheMap()->save();
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // Without comparison enabled, the file is kept as-is (old behavior preserved)
+    // — no re-download, no invalidation
+    expect(disk()->get($diskPath))->toBe('stale content');
+});
+
+it('resolves named asset with source key and re-downloads when refresh is set', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Map with explicit source key + refresh
+    Basset::map('named-widget', $assetUrl, ['refresh' => true]);
+
+    // Pre-populate with stale content
+    disk()->put($diskPath, 'stale content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+    Basset::cacheMap()->save();
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('named-widget', false)");
+
+    $this->artisan('basset:cache');
+
+    // Should re-download fresh content
+    $expectedContent = getStub('vue.global.prod.js');
+    expect(disk()->get($diskPath))->toBe($expectedContent);
+});
+
+it('uses key as source fallback when source is not set in attributes', function () {
+    $assetUrl = 'https://unpkg.com/vue@3/dist/vue.global.prod.js';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+
+    // Map where key IS the source (no explicit 'source' in attributes — just refresh)
+    Basset::map($assetUrl, $assetUrl, ['refresh' => true]);
+
+    // Pre-populate with stale content
+    disk()->put($diskPath, 'stale content');
+    Basset::cacheMap()->addAsset(
+        bassetInstance()->buildCacheEntry($assetUrl)
+    );
+    Basset::cacheMap()->save();
+
+    File::put($this->tempDir.'/test.blade.php', "@basset('$assetUrl', false)");
+
+    $this->artisan('basset:cache');
+
+    // Should re-download fresh content (key = source fallback worked)
+    $expectedContent = getStub('vue.global.prod.js');
+    expect(disk()->get($diskPath))->toBe($expectedContent);
+});

--- a/tests/Feature/CacheCommandTest.php
+++ b/tests/Feature/CacheCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Backpack\Basset\Enums\StatusEnum;
 use Backpack\Basset\Facades\Basset;
 use Illuminate\Support\Facades\File;
 

--- a/tests/Feature/DownloadValidationTest.php
+++ b/tests/Feature/DownloadValidationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use Backpack\Basset\Enums\StatusEnum;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config(['backpack.basset.cache_map' => true]);
+    config(['backpack.basset.dev_mode' => false]);
+    config(['backpack.basset.fetch_timeout' => 5]);
+    config(['backpack.basset.fetch_retries' => 3]);
+    config(['backpack.basset.fetch_retry_delay' => 0]); // no delay in tests
+});
+
+it('downloads asset on successful HTTP response', function () {
+    Http::fake([
+        'https://example.com/style.css' => Http::response('body { color: red; }', 200, ['Content-Type' => 'text/css']),
+    ]);
+
+    $result = bassetInstance('https://example.com/style.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/style.css');
+
+    expect($result)->toBe(StatusEnum::INTERNALIZED);
+    disk()->assertExists($diskPath);
+    expect(disk()->get($diskPath))->toBe('body { color: red; }');
+});
+
+it('returns invalid when HTTP response is 404', function () {
+    Http::fake([
+        'https://example.com/missing.css' => Http::response('Not Found', 404),
+    ]);
+
+    $result = bassetInstance('https://example.com/missing.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/missing.css');
+
+    expect($result)->toBe(StatusEnum::INVALID);
+    disk()->assertMissing($diskPath);
+});
+
+it('returns invalid when HTTP response is 500', function () {
+    Http::fake([
+        'https://example.com/error.css' => Http::response('Internal Server Error', 500),
+    ]);
+
+    $result = bassetInstance('https://example.com/error.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/error.css');
+
+    expect($result)->toBe(StatusEnum::INVALID);
+    disk()->assertMissing($diskPath);
+});
+
+it('returns invalid when HTTP request times out', function () {
+    Http::fake([
+        'https://example.com/slow.css' => function () {
+            throw new \Illuminate\Http\Client\ConnectionException('Connection timed out', 0);
+        },
+    ]);
+
+    $result = bassetInstance('https://example.com/slow.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/slow.css');
+
+    expect($result)->toBe(StatusEnum::INVALID);
+    disk()->assertMissing($diskPath);
+});
+
+it('does not overwrite cached asset with error response when file exists', function () {
+    $assetUrl = 'https://example.com/style.css';
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk($assetUrl);
+    $originalContent = 'body { color: blue; }';
+
+    // pre-populate with valid content
+    disk()->put($diskPath, $originalContent);
+
+    // now simulate CDN being down
+    Http::fake([
+        $assetUrl => Http::response('Service Unavailable', 503),
+    ]);
+
+    $result = bassetInstance($assetUrl, false);
+
+    // should serve from cache since file exists on disk
+    expect($result)->toBe(StatusEnum::IN_CACHE);
+
+    // the original file should NOT have been overwritten with error content
+    expect(disk()->get($diskPath))->toBe($originalContent);
+});
+
+it('retries on failure and succeeds on subsequent attempt', function () {
+    $attempts = 0;
+
+    Http::fake([
+        'https://example.com/flaky.css' => function () use (&$attempts) {
+            $attempts++;
+            if ($attempts < 3) {
+                throw new \Illuminate\Http\Client\ConnectionException("Attempt $attempts failed", 0);
+            }
+
+            return Http::response('body { color: green; }', 200);
+        },
+    ]);
+
+    $result = bassetInstance('https://example.com/flaky.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/flaky.css');
+
+    expect($result)->toBe(StatusEnum::INTERNALIZED);
+    disk()->assertExists($diskPath);
+    expect(disk()->get($diskPath))->toBe('body { color: green; }');
+    expect($attempts)->toBe(3);
+});
+
+it('retries on 5xx and succeeds on retry', function () {
+    $attempts = 0;
+
+    Http::fake([
+        'https://example.com/recover.css' => function () use (&$attempts) {
+            $attempts++;
+            if ($attempts < 3) {
+                return Http::response('Server Error', 503);
+            }
+
+            return Http::response('body { color: purple; }', 200);
+        },
+    ]);
+
+    $result = bassetInstance('https://example.com/recover.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/recover.css');
+
+    expect($result)->toBe(StatusEnum::INTERNALIZED);
+    disk()->assertExists($diskPath);
+    expect(disk()->get($diskPath))->toBe('body { color: purple; }');
+    expect($attempts)->toBe(3);
+});
+
+it('gives up after exhausting all retries', function () {
+    $attempts = 0;
+
+    Http::fake([
+        'https://example.com/down.css' => function () use (&$attempts) {
+            $attempts++;
+
+            throw new \Illuminate\Http\Client\ConnectionException("Attempt $attempts failed", 0);
+        },
+    ]);
+
+    $result = bassetInstance('https://example.com/down.css', false);
+    $diskPath = bassetInstance()->assetPathsManager->getPathOnDisk('https://example.com/down.css');
+
+    expect($result)->toBe(StatusEnum::INVALID);
+    disk()->assertMissing($diskPath);
+    expect($attempts)->toBe(3); // initial + 2 retries = 3 total attempts
+});

--- a/tests/Feature/RegisterAssetsTest.php
+++ b/tests/Feature/RegisterAssetsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Backpack\Basset\Facades\Basset;
+
+beforeEach(function () {
+    Basset::clearNamedAssets();
+});
+
+afterEach(function () {
+    Basset::clearNamedAssets();
+});
+
+// Helper: mirror the registerBassetAssets dispatch logic for testing
+function invokeRegister(array $assets): void {
+    foreach ($assets as $key => $value) {
+        if (is_string($value)) {
+            Basset::map($value, $value);
+        } elseif (array_is_list($value) && (! $value || is_string(reset($value)))) {
+            foreach ($value as $file) {
+                Basset::map($file, $file);
+            }
+        } else {
+            $source = $value['source'] ?? $key;
+            $attributes = array_diff_key($value, ['source' => null]);
+            Basset::map($key, $source, $attributes);
+        }
+    }
+}
+
+it('registers simple string assets', function () {
+    invokeRegister([
+        'https://cdn.com/a.css',
+        'https://cdn.com/b.css',
+    ]);
+
+    $named = Basset::getNamedAssets();
+    expect($named)->toHaveKeys(['https://cdn.com/a.css', 'https://cdn.com/b.css']);
+    expect($named['https://cdn.com/a.css']['source'])->toBe('https://cdn.com/a.css');
+});
+
+it('registers sequential list assets', function () {
+    invokeRegister([
+        ['https://cdn.com/x.js', 'https://cdn.com/y.js'],
+    ]);
+
+    $named = Basset::getNamedAssets();
+    expect($named)->toHaveKeys(['https://cdn.com/x.js', 'https://cdn.com/y.js']);
+});
+
+it('registers key-as-source with attributes', function () {
+    invokeRegister([
+        'https://cdn.com/refreshable.css' => ['refresh' => true],
+    ]);
+
+    $named = Basset::getNamedAssets();
+    expect($named)->toHaveKey('https://cdn.com/refreshable.css');
+    expect($named['https://cdn.com/refreshable.css']['source'])->toBe('https://cdn.com/refreshable.css');
+    expect($named['https://cdn.com/refreshable.css']['attributes'])->toBe(['refresh' => true]);
+});
+
+it('registers named asset with explicit source', function () {
+    invokeRegister([
+        'my-widget' => ['source' => 'https://cdn.com/widget.js', 'refresh' => true],
+    ]);
+
+    $named = Basset::getNamedAssets();
+    expect($named)->toHaveKey('my-widget');
+    expect($named['my-widget']['source'])->toBe('https://cdn.com/widget.js');
+    expect($named['my-widget']['attributes'])->toBe(['refresh' => true]);
+});
+
+it('treats numeric-keyed assoc as named asset, not sequential list', function () {
+    invokeRegister([
+        ['source' => 'https://cdn.com/widget.js', 'refresh' => true],
+    ]);
+
+    $named = Basset::getNamedAssets();
+    // Key 0, treated as associative because values aren't strings
+    expect($named)->toHaveKey(0);
+    expect($named[0]['source'])->toBe('https://cdn.com/widget.js');
+    expect($named[0]['attributes'])->toBe(['refresh' => true]);
+});
+
+it('handles empty array gracefully', function () {
+    invokeRegister([]);
+
+    expect(Basset::getNamedAssets())->toBe([]);
+});
+
+it('handles mixed formats together', function () {
+    invokeRegister([
+        'https://cdn.com/simple.js',
+        'https://cdn.com/refresher.js' => ['refresh' => true],
+        'my-widget' => ['source' => 'https://cdn.com/widget.js'],
+        ['https://cdn.com/a.js', 'https://cdn.com/b.js'],
+    ]);
+
+    $named = Basset::getNamedAssets();
+    expect($named)->toHaveKeys([
+        'https://cdn.com/simple.js',
+        'https://cdn.com/refresher.js',
+        'my-widget',
+        'https://cdn.com/a.js',
+        'https://cdn.com/b.js',
+    ]);
+});
+
+it('handles empty sequential array without crash', function () {
+    invokeRegister([
+        [],
+    ]);
+
+    expect(Basset::getNamedAssets())->toBe([]);
+});

--- a/tests/Feature/RegisterAssetsTest.php
+++ b/tests/Feature/RegisterAssetsTest.php
@@ -11,7 +11,8 @@ afterEach(function () {
 });
 
 // Helper: mirror the registerBassetAssets dispatch logic for testing
-function invokeRegister(array $assets): void {
+function invokeRegister(array $assets): void
+{
     foreach ($assets as $key => $value) {
         if (is_string($value)) {
             Basset::map($value, $value);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,6 +45,11 @@ uses(BaseTest::class)
 
         File::put(public_path('bootstrap/js/bootstrap.min.js'), getStub('bootstrap.min.js'));
         File::put(public_path('bootstrap/css/bootstrap.min.css'), getStub('bootstrap.min.css'));
+
+        // Clear the private .basset file to prevent cross-test contamination
+        if (File::exists(storage_path('basset/.basset'))) {
+            File::delete(storage_path('basset/.basset'));
+        }
     })
     ->in(__DIR__);
 


### PR DESCRIPTION
this introduces some "much needed" features: 
1 - move .basset cache file outside of public folder. It's a possible security issue to have all packages used in your admin panel exposed via a public file accessible by anyone (not logged in users included). 
2 - basset:cache now check for http errors, have a "safe" retry period before failing, and does not cache error responses. 
3 - basset:cache is now the "holy grail", possible to completely sunset basset:clear. The objective is straighfoward: avoid downloading already cached assets (reducing the risk of outages if the cdn is down), prune non-mentioned basset files in any app file (like changing the version of some cdn cache file). 

I've checked, and in backpack all files referenced as url are versioned. Local files still keep the same behavior, always re-cache, it's just a "move file" operation, not a complete http request. 

I know you have been keeping an eye in some of this issue, would you like to have this a go before we merge @jnoordsij ?

Thanks