### PR TITLE
remove asset_hash as it was not used

### DIFF
--- a/src/AssetHashManager.php
+++ b/src/AssetHashManager.php
@@ -15,9 +15,4 @@ final class AssetHashManager implements AssetHashManagerInterface
     {
         return preg_replace('/\.(css|js)$/i', "-{$hash}.$1", $path);
     }
-
-    public function validateHash(string $content, string $hash): bool
-    {
-        return $this->generateHash($content) === $hash;
-    }
 }

--- a/src/BassetManager.php
+++ b/src/BassetManager.php
@@ -201,7 +201,7 @@ class BassetManager
                 // Cache map entry exists but file is missing — remove stale entry and re-download
                 $this->cacheMap->delete($mapped);
             } else {
-                // Dev mode: compare URL or content hash to detect changes
+                // Dev mode: compare URL to detect changes
                 if (Str::isUrl($mapped->getAssetPath())) {
                     if ($mapped->getAssetPath() !== $asset->getAssetPath()) {
                         return $this->replaceAsset($asset, $mapped, $output);
@@ -210,10 +210,6 @@ class BassetManager
                     $output && $this->output->write($mapped);
 
                     return $this->loader->finish(StatusEnum::IN_CACHE);
-                }
-
-                if ($mapped->getContentHash() !== $asset->generateContentHash()) {
-                    return $this->replaceAsset($asset, $mapped, $output);
                 }
             }
         }

--- a/src/Contracts/AssetHashManagerInterface.php
+++ b/src/Contracts/AssetHashManagerInterface.php
@@ -7,6 +7,4 @@ interface AssetHashManagerInterface
     public function generateHash(string $content): string;
 
     public function appendHashToPath(string $path, string $hash): string;
-
-    public function validateHash(string $content, string $hash): bool;
 }

--- a/src/Helpers/CacheEntry.php
+++ b/src/Helpers/CacheEntry.php
@@ -20,8 +20,6 @@ final class CacheEntry implements Arrayable, JsonSerializable
 
     private array $assetAttributes = [];
 
-    private string $assetContentHash = '';
-
     private bool $isPublicFile = false;
 
     private AssetPathManager $assetPathsManager;
@@ -85,10 +83,6 @@ final class CacheEntry implements Arrayable, JsonSerializable
 
         if (! isset($this->assetDiskPath)) {
             $this->assetDiskPath = $this->getPathOnDisk($this->assetPathsManager->getCleanPath($assetPath));
-        }
-
-        if ($this->isLocalAsset()) {
-            $this->generateContentHash();
         }
 
         return $this;
@@ -156,7 +150,6 @@ final class CacheEntry implements Arrayable, JsonSerializable
             'asset_path' => $this->assetPath,
             'asset_disk_path' => isset($this->assetDiskPath) ? $this->assetDiskPath : $this->getPathOnDisk($this->assetPath),
             'asset_attributes' => $this->assetAttributes,
-            'asset_content_hash' => $this->assetContentHash,
         ];
     }
 
@@ -179,28 +172,14 @@ final class CacheEntry implements Arrayable, JsonSerializable
         return $content;
     }
 
-    public function getContentHash(): string
-    {
-        return $this->assetContentHash;
-    }
-
     public function getPathOnDiskHashed(string $content): string
     {
         $path = $this->assetPathsManager->getPathOnDisk($this->assetPath);
-
-        // get the hash for the content
         $hash = $this->assetHashManager->generateHash($content);
 
-        $this->assetContentHash = $this->assetHashManager->appendHashToPath($content, $hash);
+        $this->assetDiskPath = $this->assetHashManager->appendHashToPath($path, $hash);
 
-        return $path;
-    }
-
-    public function generateContentHash(?string $content = null): string
-    {
-        $content = $content ?? $this->getContent();
-
-        return $this->assetContentHash = $this->assetHashManager->generateHash($content);
+        return $this->assetDiskPath;
     }
 
     private function getPathOnDisk(string $asset): string

--- a/tests/Feature/ContentHashTest.php
+++ b/tests/Feature/ContentHashTest.php
@@ -1,0 +1,52 @@
+<?php
+
+beforeEach(function () {
+    config(['backpack.basset.path' => 'basset']);
+});
+
+it('getPathOnDiskHashed stores actual hash and returns hashed path', function () {
+    $entry = bassetInstance()->buildCacheEntry('test-block.js');
+    $code = 'console.log("hello world");';
+
+    $path = $entry->getPathOnDiskHashed($code);
+
+    // The returned path should include an 8-char hash before .js
+    expect($path)->toMatch('/^basset\/test-block-\w{8}\.js$/');
+
+    // The hash is embedded in the filename — extract it
+    preg_match('/-(\w{8})\.js$/', $path, $m);
+    expect($m[1])->toHaveLength(8);
+    expect($m[1])->toMatch('/^\w{8}$/');
+});
+
+it('getPathOnDiskHashed generates different hashes for different content', function () {
+    $entry1 = bassetInstance()->buildCacheEntry('test-block.js');
+    $path1 = $entry1->getPathOnDiskHashed('console.log("hello");');
+
+    $entry2 = bassetInstance()->buildCacheEntry('test-block.js');
+    $path2 = $entry2->getPathOnDiskHashed('console.log("world");');
+
+    // Different content → different hash → different path
+    expect($path1)->not->toBe($path2);
+});
+
+it('getPathOnDiskHashed produces same hash for identical content', function () {
+    $code = 'console.log("hello");';
+
+    $entry1 = bassetInstance()->buildCacheEntry('test-block.js');
+    $path1 = $entry1->getPathOnDiskHashed($code);
+
+    $entry2 = bassetInstance()->buildCacheEntry('test-block.js');
+    $path2 = $entry2->getPathOnDiskHashed($code);
+
+    // Same content → same hash → same path
+    expect($path1)->toBe($path2);
+});
+
+it('getPathOnDiskHashed sets assetDiskPath to the hashed path', function () {
+    $entry = bassetInstance()->buildCacheEntry('test-block.js');
+    $path = $entry->getPathOnDiskHashed('some code');
+
+    expect($entry->getAssetDiskPath())->toBe($path);
+    expect($entry->getAssetDiskPath())->toMatch('/-\w{8}\.js$/');
+});


### PR DESCRIPTION
The asset_content_hash was a dead branch. 
It had it's purpose, but in the end I decided it was overkill and overengineering something that had simpler and effective ways to deal with.

 

